### PR TITLE
fix(e22-s1): resilient schema validators normalize instead of reject

### DIFF
--- a/docs/sprint-artifacts/sprint-status.yaml
+++ b/docs/sprint-artifacts/sprint-status.yaml
@@ -303,7 +303,7 @@ development_status:
   # 0/5 stories complete — EPIC IN PROGRESS
   # SCP: docs/sprint-artifacts/change-proposals/sprint-change-proposal-20260226-post-phase67-remediation.md
   epic-22: in-progress
-  e22-s1-schema-resilience: drafted
+  e22-s1-schema-resilience: done  # 2026-02-26: Resilient validators — normalize instead of reject. risk_status Moderate->Medium, all validators audited.
   e22-s2-dashboard-layout-fix: drafted
   e22-s3-job-detail-source-layout: drafted
   e22-s4-building-tabs-everywhere: drafted

--- a/open_notebook/extractors/acm_schemas.py
+++ b/open_notebook/extractors/acm_schemas.py
@@ -11,10 +11,15 @@ import re
 from enum import Enum
 from typing import List, Optional
 
+from loguru import logger
 from pydantic import BaseModel, Field, field_validator
 
 # Import ExtractionConfidence from domain to avoid duplication
 from open_notebook.domain.acm import ExtractionConfidence
+from open_notebook.extractors.normalizers.enums import (
+    RISK_STATUS_SYNONYMS,
+    normalize_enum_value,
+)
 
 # BAR field enums — canonical allowed values
 RESULT_VALUES = {
@@ -253,17 +258,15 @@ class ACMExtractionRecord(BaseModel):
     def validate_result(cls, v: Optional[str]) -> Optional[str]:
         if v is None:
             return v
-        normalized = v.strip().title()
-        # Handle "Assumed positive" -> "Assumed Positive" etc.
-        if normalized not in RESULT_VALUES:
-            # Try case-insensitive match
-            for valid in RESULT_VALUES:
-                if v.strip().lower() == valid.lower():
-                    return valid
-            raise ValueError(
-                f"result must be one of {sorted(RESULT_VALUES)}, got '{v}'"
-            )
-        return normalized
+        stripped = str(v).strip()
+
+        # Case-insensitive canonical match
+        for valid in RESULT_VALUES:
+            if stripped.lower() == valid.lower():
+                return valid
+
+        logger.warning(f"Unknown result value: '{v}' - passing through")
+        return stripped
 
     @field_validator("friable", mode="before")
     @classmethod
@@ -272,14 +275,20 @@ class ACMExtractionRecord(BaseModel):
             return v
         if _is_na(v):
             return None
-        stripped = v.strip()
-        for valid in FRIABLE_VALUES:
-            if stripped.lower() == valid.lower():
-                return valid
-        # Accept common variants
-        if stripped.lower() in ("non-friable", "nonfriable"):
+        stripped = str(v).strip()
+
+        lowered = stripped.lower().replace("-", " ")
+        if lowered in {"friable", "f"}:
+            return "Friable"
+        if lowered in {"non friable", "nonfriable", "nf"}:
             return "Non Friable"
-        raise ValueError(f"friable must be one of {sorted(FRIABLE_VALUES)}, got '{v}'")
+
+        for valid in FRIABLE_VALUES:
+            if lowered == valid.lower():
+                return valid
+
+        logger.warning(f"Unknown friable value: '{v}' - passing through")
+        return stripped
 
     @field_validator("risk_status", mode="before")
     @classmethod
@@ -288,19 +297,22 @@ class ACMExtractionRecord(BaseModel):
             return v
         if _is_na(v):
             return None
-        normalized = v.strip().title()
-        if normalized in RISK_STATUS_VALUES:
-            return normalized
-        raise ValueError(
-            f"risk_status must be one of {sorted(RISK_STATUS_VALUES)}, got '{v}'"
-        )
+
+        lookup = str(v).strip().lower()
+        if lookup in RISK_STATUS_SYNONYMS:
+            return RISK_STATUS_SYNONYMS[lookup]
+
+        stripped = str(v).strip()
+        logger.warning(f"Unknown risk_status value: '{v}' - passing through")
+        return stripped
 
     @field_validator("material_condition", mode="before")
     @classmethod
     def validate_material_condition(cls, v: Optional[str]) -> Optional[str]:
         if v is None:
             return v
-        stripped = v.strip()
+        stripped = str(v).strip()
+
         # Check for specific N/A enum values BEFORE generic _is_na() check
         # (otherwise "N/A (negative)" would be stripped to None)
         na_condition_values = {
@@ -311,12 +323,17 @@ class ACMExtractionRecord(BaseModel):
             return na_condition_values[stripped.lower()]
         if _is_na(v):
             return None
-        normalized = stripped.title()
-        if normalized in MATERIAL_CONDITION_VALUES:
-            return normalized
-        raise ValueError(
-            f"material_condition must be one of {sorted(MATERIAL_CONDITION_VALUES)}, got '{v}'"
-        )
+
+        normalized = normalize_enum_value(stripped, "condition")
+        if normalized is None:
+            return None
+
+        for valid in MATERIAL_CONDITION_VALUES:
+            if normalized.lower() == valid.lower():
+                return valid
+
+        logger.warning(f"Unknown material_condition value: '{v}' - passing through")
+        return stripped
 
     @field_validator("area_type", mode="before")
     @classmethod
@@ -325,12 +342,13 @@ class ACMExtractionRecord(BaseModel):
             return v
         if _is_na(v):
             return None
-        normalized = v.strip().title()
-        if normalized in AREA_TYPE_VALUES:
-            return normalized
-        raise ValueError(
-            f"area_type must be one of {sorted(AREA_TYPE_VALUES)}, got '{v}'"
-        )
+        stripped = str(v).strip()
+        for valid in AREA_TYPE_VALUES:
+            if stripped.lower() == valid.lower():
+                return valid
+
+        logger.warning(f"Unknown area_type value: '{v}' - passing through")
+        return stripped
 
     @field_validator("quantity", mode="before")
     @classmethod
@@ -363,7 +381,12 @@ class ACMExtractionRecord(BaseModel):
         """Coerce None → [] so LLMs returning ``"data_issues": null`` pass validation."""
         if v is None:
             return []
-        return v  # type: ignore[return-value]
+        if isinstance(v, list):
+            return [str(item) for item in v]
+        if isinstance(v, str):
+            stripped = v.strip()
+            return [stripped] if stripped else []
+        return [str(v)]
 
 
 class ACMExtractionResult(BaseModel):

--- a/open_notebook/extractors/normalizers/enums.py
+++ b/open_notebook/extractors/normalizers/enums.py
@@ -51,11 +51,30 @@ DISTURBANCE_SYNONYMS: dict[str, Optional[str]] = {
     "n/a": None,
 }
 
+# Risk Status synonyms → canonical extraction values
+# NOTE: risk_status uses "Medium" (not BAR disturbance "Moderate")
+RISK_STATUS_SYNONYMS: dict[str, Optional[str]] = {
+    "high": "High",
+    "h": "High",
+    "medium": "Medium",
+    "med": "Medium",
+    "m": "Medium",
+    "moderate": "Medium",
+    "low": "Low",
+    "l": "Low",
+    "none": None,
+    "n/a": None,
+    "na": None,
+    "unknown": None,
+    "-": None,
+}
+
 # Map field_name → synonym dictionary
 _SYNONYM_MAP: dict[str, dict] = {
     "sample_result": SAMPLE_RESULT_SYNONYMS,
     "condition": CONDITION_SYNONYMS,
     "disturbance_potential": DISTURBANCE_SYNONYMS,
+    "risk_status": RISK_STATUS_SYNONYMS,
 }
 
 

--- a/open_notebook/extractors/validators/acm_validator.py
+++ b/open_notebook/extractors/validators/acm_validator.py
@@ -12,6 +12,7 @@ from typing import Optional
 from loguru import logger
 from pydantic import BaseModel
 
+from open_notebook.extractors.normalizers.enums import normalize_enum_value
 from open_notebook.extractors.parsers.config_loader import load_field_schema
 
 
@@ -49,6 +50,14 @@ _ENUM_FIELD_MAP: dict[str, str] = {
     "disturbance_potential": "DisturbancePotential",
 }
 
+# Enum field name → enum normalizer field mapping
+_ENUM_NORMALIZER_FIELD_MAP: dict[str, str] = {
+    "sample_result": "sample_result",
+    "material_condition": "condition",
+    "friable": "friability",
+    "disturbance_potential": "disturbance_potential",
+}
+
 
 _cached_enums: Optional[dict[str, list[str]]] = None
 
@@ -64,6 +73,43 @@ def _load_enum_values() -> dict[str, list[str]]:
     config = load_field_schema()
     _cached_enums = config.enums
     return _cached_enums
+
+
+def _append_data_issue(record: dict, message: str) -> None:
+    """Append a data issue to record without creating duplicates."""
+    raw_issues = record.get("data_issues")
+
+    if isinstance(raw_issues, list):
+        issues = raw_issues
+    elif raw_issues is None:
+        issues = []
+        record["data_issues"] = issues
+    elif isinstance(raw_issues, str):
+        stripped = raw_issues.strip()
+        issues = [stripped] if stripped else []
+        record["data_issues"] = issues
+    else:
+        issues = [str(raw_issues)]
+        record["data_issues"] = issues
+
+    if message not in issues:
+        issues.append(message)
+
+
+def _normalize_enum_for_validation(field_name: str, raw_value: str) -> Optional[str]:
+    """Normalize enum values while preserving passthrough for unknowns."""
+    if field_name == "friable":
+        lowered = raw_value.strip().lower().replace("-", " ")
+        if lowered in {"friable", "f"}:
+            return "Friable"
+        if lowered in {"non friable", "nonfriable", "nf"}:
+            return "Non Friable"
+        if lowered in {"none", "n/a", "na", "unknown", "-"}:
+            return None
+        return raw_value.strip()
+
+    normalizer_field = _ENUM_NORMALIZER_FIELD_MAP.get(field_name, field_name)
+    return normalize_enum_value(raw_value, normalizer_field)
 
 
 def validate_enum_fields(record: dict) -> list[ValidationIssue]:
@@ -86,6 +132,26 @@ def validate_enum_fields(record: dict) -> list[ValidationIssue]:
         if value is None or value == "":
             continue
 
+        raw_value = str(value).strip()
+        if not raw_value:
+            continue
+
+        normalized_value = _normalize_enum_for_validation(field_name, raw_value)
+
+        if normalized_value != raw_value:
+            record[field_name] = normalized_value
+            _append_data_issue(
+                record,
+                f"Normalized {field_name}: {raw_value} -> {normalized_value}",
+            )
+            logger.info(
+                f"Normalized enum field {field_name}: '{raw_value}' -> "
+                f"'{normalized_value}'"
+            )
+
+        if normalized_value is None:
+            continue
+
         valid_values = enums.get(enum_key, [])
         if not valid_values:
             continue
@@ -94,17 +160,39 @@ def validate_enum_fields(record: dict) -> list[ValidationIssue]:
         def _norm(s: str) -> str:
             return s.strip().lower().replace("-", " ")
 
-        value_norm = _norm(value)
-        if not any(_norm(v) == value_norm for v in valid_values):
-            issues.append(
-                ValidationIssue(
-                    field_name=field_name,
-                    current_value=value,
-                    expected_format="enum",
-                    valid_values=valid_values,
-                    issue_type="enum_mismatch",
-                )
+        value_norm = _norm(str(normalized_value))
+
+        canonical_value = None
+        for valid in valid_values:
+            if _norm(valid) == value_norm:
+                canonical_value = valid
+                break
+
+        if canonical_value is not None:
+            if field_name == "friable":
+                record[field_name] = normalized_value
+            else:
+                record[field_name] = canonical_value
+            continue
+
+        _append_data_issue(
+            record,
+            f"Unrecognized {field_name}: {normalized_value}",
+        )
+        logger.warning(
+            f"Unrecognized enum field {field_name}: '{normalized_value}' "
+            f"(raw='{raw_value}')"
+        )
+
+        issues.append(
+            ValidationIssue(
+                field_name=field_name,
+                current_value=str(normalized_value),
+                expected_format="enum",
+                valid_values=valid_values,
+                issue_type="enum_mismatch",
             )
+        )
 
     return issues
 

--- a/tests/test_acm_schemas.py
+++ b/tests/test_acm_schemas.py
@@ -250,3 +250,48 @@ class TestMergeRecordsDataIssuesNullSafe:
         merged = _merge_records(existing, new)
         assert set(merged.data_issues) == {"dup", "unique_a", "unique_b"}
         assert len(merged.data_issues) == 3  # no duplicates
+
+
+class TestSchemaEnumResilience:
+    """Schema validators should normalize/pass through instead of rejecting records."""
+
+    _BASE = {
+        "building_id": "B01",
+        "product": "Vinyl Tiles",
+        "result": "Positive",
+    }
+
+    def _make(self, **kwargs):
+        from open_notebook.extractors.acm_schemas import ACMExtractionRecord
+
+        return ACMExtractionRecord(**{**self._BASE, **kwargs})
+
+    def test_risk_status_moderate_normalizes_to_medium(self):
+        record = self._make(risk_status="Moderate")
+        assert record.risk_status == "Medium"
+
+    def test_unknown_risk_status_passes_through(self):
+        record = self._make(risk_status="Critical")
+        assert record.risk_status == "Critical"
+
+    def test_unknown_friable_passes_through(self):
+        record = self._make(friable="Sometimes")
+        assert record.friable == "Sometimes"
+
+    def test_unknown_material_condition_passes_through(self):
+        record = self._make(material_condition="Excellent")
+        assert record.material_condition == "Excellent"
+
+    def test_unknown_area_type_passes_through(self):
+        record = self._make(area_type="Roof")
+        assert record.area_type == "Roof"
+
+    def test_unknown_result_passes_through(self):
+        record = self._make(result="Maybe")
+        assert record.result == "Maybe"
+
+    def test_quantity_negative_still_rejected(self):
+        from open_notebook.extractors.acm_schemas import ACMExtractionRecord
+
+        with pytest.raises(ValidationError, match="quantity cannot be negative"):
+            ACMExtractionRecord(**{**self._BASE, "quantity": "-5 m2"})

--- a/tests/test_acm_validator.py
+++ b/tests/test_acm_validator.py
@@ -87,13 +87,44 @@ class TestValidateEnumFields:
             "sample_result": "Positive",
             "material_condition": "Excellent",  # Invalid
             "friable": "Non-friable",
-            "disturbance_potential": "Medium",  # Invalid — BAR uses "Moderate"
+            "disturbance_potential": "Medium",  # Normalized to "Moderate"
         }
         issues = validate_enum_fields(record)
-        assert len(issues) == 2
+        assert len(issues) == 1
         fields_flagged = {i.field_name for i in issues}
         assert "material_condition" in fields_flagged
-        assert "disturbance_potential" in fields_flagged
+
+    def test_disturbance_medium_is_normalized_not_flagged(self):
+        """'Medium' disturbance value should normalize to BAR 'Moderate'."""
+        record = {
+            "disturbance_potential": "Medium",
+            "data_issues": [],
+        }
+
+        issues = validate_enum_fields(record)
+
+        assert len(issues) == 0
+        assert record["disturbance_potential"] == "Moderate"
+        assert any(
+            issue == "Normalized disturbance_potential: Medium -> Moderate"
+            for issue in record["data_issues"]
+        )
+
+    def test_invalid_enum_is_recorded_in_data_issues(self):
+        """Unrecognized enum values should be tracked in data_issues."""
+        record = {
+            "sample_result": "Bonded",
+            "data_issues": [],
+        }
+
+        issues = validate_enum_fields(record)
+
+        assert len(issues) == 1
+        assert issues[0].field_name == "sample_result"
+        assert any(
+            issue == "Unrecognized sample_result: Bonded"
+            for issue in record["data_issues"]
+        )
 
     def test_issue_contains_valid_values(self):
         """Validation issue should include valid enum values for correction guidance."""
@@ -229,11 +260,11 @@ class TestValidateACMRecord:
             "sample_result": "Positive",
             "material_condition": "Excellent",  # Invalid
             "friable": "Non-friable",
-            "disturbance_potential": "Medium",  # Invalid
+            "disturbance_potential": "Medium",  # Normalized to "Moderate"
         }
         result = validate_acm_record(record)
         assert result.is_valid is False
-        assert len(result.issues) == 2
+        assert len(result.issues) == 1
 
     def test_record_with_business_rule_violations(self):
         """Record violating business rules should have is_valid=False."""

--- a/tests/test_enum_normalizer.py
+++ b/tests/test_enum_normalizer.py
@@ -227,3 +227,25 @@ class TestEdgeCases:
         assert normalize_enum_value("friable", "friability") == "Friable"
         assert normalize_enum_value("NF", "friability") == "Non-friable"
         assert normalize_enum_value("F", "friability") == "Friable"
+
+
+class TestRiskStatusNormalization:
+    """Tests for risk_status normalization (E22-S1)."""
+
+    def test_moderate_maps_to_medium(self):
+        from open_notebook.extractors.normalizers.enums import normalize_enum_value
+
+        assert normalize_enum_value("Moderate", "risk_status") == "Medium"
+
+    def test_shorthand_maps_to_canonical(self):
+        from open_notebook.extractors.normalizers.enums import normalize_enum_value
+
+        assert normalize_enum_value("h", "risk_status") == "High"
+        assert normalize_enum_value("med", "risk_status") == "Medium"
+        assert normalize_enum_value("l", "risk_status") == "Low"
+
+    def test_na_values_map_to_none(self):
+        from open_notebook.extractors.normalizers.enums import normalize_enum_value
+
+        assert normalize_enum_value("n/a", "risk_status") is None
+        assert normalize_enum_value("unknown", "risk_status") is None


### PR DESCRIPTION
## Summary
- Make ACM schema validators resilient by normalizing or passing through unexpected enum-like values instead of raising hard validation errors.
- Add explicit `risk_status` normalization (`Moderate` -> `Medium`) and shared `RISK_STATUS_SYNONYMS` support in enum normalizers.
- Update enum validation to normalize first and record normalization/unrecognized values in `data_issues` for auditability.
- Mark sprint artifact `e22-s1-schema-resilience` as done.

## Files Changed
- `open_notebook/extractors/acm_schemas.py`
- `open_notebook/extractors/validators/acm_validator.py`
- `open_notebook/extractors/normalizers/enums.py`
- `tests/test_acm_schemas.py`
- `tests/test_acm_validator.py`
- `tests/test_enum_normalizer.py`
- `docs/sprint-artifacts/sprint-status.yaml`

## Validation
- `uv run ruff check open_notebook/extractors/acm_schemas.py`
- `uv run ruff check open_notebook/extractors/validators/`
- `uv run ruff check open_notebook/extractors/normalizers/`
- `uv run pytest tests/ -k "schema or validator or extraction or normaliz" -v --tb=short`
- `uv run pytest tests/test_acm_schemas.py tests/test_acm_validator.py tests/test_enum_normalizer.py -v --tb=short`

## Notes
- Full suite currently has 3 pre-existing failures unrelated to this story:
  - `tests/test_broadmeadows_e2e.py::test_broadmeadows_all_records_extracted`
  - `tests/test_page_tagger.py::TestTagPagesAsync::test_tag_pages_heuristic_fallback`
  - `tests/test_page_tagger.py::TestTagPagesAsync::test_tag_pages_with_building_inventory`