### PR TITLE
feat(e21-s4): raw table preview + extraction input quality fix

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -630,6 +630,19 @@ class ParentContextResponse(BaseModel):
     raw_text: Optional[str] = None
 
 
+class RawTableResponse(BaseModel):
+    """Raw table preview payload for job extraction diagnostics."""
+
+    id: str
+    source_id: str
+    page_start: int
+    page_end: int
+    table_type: Optional[str] = None
+    raw_html: Optional[str] = None
+    raw_text: Optional[str] = None
+    building_name: Optional[str] = None
+
+
 class ACMSearchResultResponse(BaseModel):
     """Single ACM search result with similarity score."""
 

--- a/api/routers/acm.py
+++ b/api/routers/acm.py
@@ -8,6 +8,7 @@ listing, filtering, extraction, and export.
 import csv
 import io
 import math
+import re
 from datetime import date
 from typing import Optional
 
@@ -47,6 +48,7 @@ from api.models import (
     NormalizeRequest,
     NormalizeResponse,
     ParentContextResponse,
+    RawTableResponse,
     ReEmbedRequest,
     ReEmbedResponse,
     SiteConfigRequest,
@@ -1265,6 +1267,83 @@ _ACM_RECORD_BUILDING_FIELDS = {
     "postcode",
 }
 
+_PAGE_MARKER_PATTERNS = (
+    re.compile(r"<!--\s*Page\s+(\d+)\s*-->", re.IGNORECASE),
+    re.compile(r"[-—]+\s*Page\s+(\d+)\s*[-—]+", re.IGNORECASE),
+    re.compile(r"PAGE\s+(\d+)\s+OF\s+\d+", re.IGNORECASE),
+)
+
+
+def _extract_page_marker(line: str) -> Optional[int]:
+    """Extract page number from a Docling page marker line."""
+    for pattern in _PAGE_MARKER_PATTERNS:
+        match = pattern.search(line)
+        if match:
+            return int(match.group(1))
+    return None
+
+
+def _is_markdown_table_line(line: str) -> bool:
+    """Return True when a line resembles a markdown table row."""
+    stripped = line.strip()
+    return stripped.count("|") >= 2 and not stripped.startswith("```")
+
+
+def _extract_docling_markdown_tables(
+    full_text: str,
+    source_id: str,
+) -> list[RawTableResponse]:
+    """Extract markdown table blocks from Docling text grouped by page markers."""
+    if not full_text.strip():
+        return []
+
+    tables: list[RawTableResponse] = []
+    current_page = 1
+    table_start_page = 1
+    table_lines: list[str] = []
+
+    def flush_table(page_end: int) -> None:
+        nonlocal table_lines, table_start_page
+        if not table_lines:
+            return
+
+        raw_text = "\n".join(table_lines).strip()
+        table_lines = []
+        if not raw_text:
+            return
+
+        table_index = len(tables) + 1
+        tables.append(
+            RawTableResponse(
+                id=f"docling_table:{source_id}:{table_index}",
+                source_id=source_id,
+                page_start=table_start_page,
+                page_end=page_end,
+                table_type="docling_markdown",
+                raw_text=raw_text,
+            )
+        )
+
+    for line in full_text.splitlines():
+        page_marker = _extract_page_marker(line)
+        if page_marker is not None:
+            flush_table(current_page)
+            current_page = page_marker
+            continue
+
+        if _is_markdown_table_line(line):
+            if not table_lines:
+                table_start_page = current_page
+            table_lines.append(line.rstrip())
+            continue
+
+        if table_lines:
+            flush_table(current_page)
+
+    flush_table(current_page)
+    return tables
+
+
 # site_config fields managed at the source level
 _SITE_CONFIG_BUILDING_FIELDS = {
     "department",
@@ -1317,6 +1396,63 @@ def _build_building_response(
         else None,
         additional_comments=sc.additional_comments if sc else None,
     )
+
+
+@router.get("/jobs/{source_id}/raw-tables", response_model=list[RawTableResponse])
+async def list_raw_tables_for_job(source_id: str):
+    """Return raw table blocks for a job, preferring MinerU HTML when available."""
+    try:
+        normalized_source_id = ensure_record_id(source_id)
+
+        sections = await ACMTableSection.get_by_source(source_id)
+        mineru_sections = [section for section in sections if section.raw_html]
+
+        if mineru_sections:
+            return [
+                RawTableResponse(
+                    id=str(section.id) if section.id else "",
+                    source_id=str(section.source_id),
+                    page_start=section.page_start,
+                    page_end=section.page_end,
+                    table_type=section.table_type or "mineru_html",
+                    raw_html=section.raw_html,
+                    raw_text=section.raw_text,
+                    building_name=section.building_name,
+                )
+                for section in mineru_sections
+            ]
+
+        section_text_rows = [section for section in sections if section.raw_text]
+        if section_text_rows:
+            return [
+                RawTableResponse(
+                    id=str(section.id) if section.id else "",
+                    source_id=str(section.source_id),
+                    page_start=section.page_start,
+                    page_end=section.page_end,
+                    table_type=section.table_type or "register_raw_text",
+                    raw_text=section.raw_text,
+                    building_name=section.building_name,
+                )
+                for section in section_text_rows
+            ]
+
+        from open_notebook.domain.notebook import Source
+
+        source = await Source.get(source_id)
+        if not source:
+            raise HTTPException(status_code=404, detail="Source not found")
+
+        return _extract_docling_markdown_tables(
+            source.full_text or "",
+            str(normalized_source_id),
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error loading raw tables for source {source_id}: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
 
 
 @router.get("/jobs/{source_id}/buildings", response_model=list[BuildingResponse])

--- a/docs/sprint-artifacts/e21-s4-raw-table-preview-extraction-input-quality-fix.md
+++ b/docs/sprint-artifacts/e21-s4-raw-table-preview-extraction-input-quality-fix.md
@@ -1,0 +1,33 @@
+---
+epic: Epic 21
+story_id: E21-S4
+title: Raw Table Preview + Extraction Input Quality Fix
+status: done
+---
+
+As a compliance officer,
+I want to inspect raw extracted table content and improve extraction input quality,
+So that missing ACM rows can be diagnosed and extraction accuracy can improve without prompt churn.
+
+Acceptance Criteria:
+- [x] Added content normalizer for Docling split-value patterns before extraction prompt input.
+- [x] Added raw tables endpoint: `GET /api/acm/jobs/{source_id}/raw-tables`.
+- [x] Endpoint returns `acm_table_section` rows when available and falls back to Docling markdown table parsing.
+- [x] Added unit/integration coverage for normalizer and raw tables endpoint.
+- [x] Preserved fallback behavior and existing extraction graph topology.
+
+Implementation Notes:
+- `open_notebook/extractors/normalizers/content.py` added with targeted line-break fixes (e.g. `Same as\n34511-039001`, `Assumed\npositive`, split sample numbers).
+- Normalization is wired into both extraction paths:
+  - `open_notebook/graphs/acm_extraction.py` (`prepare_context`)
+  - `open_notebook/extractors/orchestrator.py` (`orchestrate_extraction`)
+- `api/models.py` includes `RawTableResponse` model.
+- `api/routers/acm.py` includes raw table endpoint and fallback table parsing helpers.
+
+Validation Notes (2026-02-26):
+- Broadmeadows (`source:z2a59rp36ur25znpaavr`): **17/31** after two extraction attempts (target `>= 28/31` not met).
+- Alexander (`source:ubbsh2i0b6ypy64vs1hh`): **52** records extracted (no complete regression to zero; historical expectation of 54 not reached in this run).
+- Raw table preview endpoint returns payload for Broadmeadows (large `acm_table_section` content, truncated in CLI output).
+
+Follow-up:
+- Prompt-only ceiling remains for Broadmeadows reference/unsampled rows; additional structural extraction strategy is still required to reach `>= 28/31`.

--- a/docs/sprint-artifacts/sprint-status.yaml
+++ b/docs/sprint-artifacts/sprint-status.yaml
@@ -298,6 +298,7 @@ development_status:
   e21-s1-loading-states-transitions: done  # 2026-02-26: loading.tsx for all job routes, shimmer skeletons, state machine
   e21-s2-jobs-layout-consistency: done  # 2026-02-26: ACM Register layout patterns applied to all jobs pages
   e21-s3-extraction-progress-feedback: done  # 2026-02-26: Upload→extract redirect, SSE wiring, job card progress, building review banner
+  e21-s4-raw-table-preview-extraction-input-quality-fix: done  # 2026-02-26: Backend-only raw table preview endpoint + Docling split-value normalizer wired into extraction paths. Broadmeadows remains 17/31 (target >=28 pending follow-up).
 
   # Epic 22: Post-Audit Remediation & Feature Completion (P0/P1)
   # 5/5 stories complete — EPIC COMPLETE

--- a/open_notebook/extractors/normalizers/__init__.py
+++ b/open_notebook/extractors/normalizers/__init__.py
@@ -10,6 +10,7 @@ Modules:
 - enums: Enum value normalization for SampleResult, Condition, etc. (E1-S12)
 """
 
+from .content import normalize_docling_text
 from .enums import normalize_enum_value
 from .recommendations import (
     CANONICAL_ACTIONS,
@@ -37,6 +38,8 @@ __all__ = [
     "CANONICAL_ACTIONS",
     "NormalizationResult",
     "normalize_recommendation",
+    # Content normalization (E21-S4)
+    "normalize_docling_text",
     # Enums (E1-S12)
     "normalize_enum_value",
 ]

--- a/open_notebook/extractors/normalizers/content.py
+++ b/open_notebook/extractors/normalizers/content.py
@@ -1,0 +1,95 @@
+"""Docling content normalization helpers for ACM extraction."""
+
+import re
+from typing import Dict, Tuple
+
+from loguru import logger
+
+_NORMALIZATION_RULES: Tuple[Tuple[str, str, str, int], ...] = (
+    (
+        r"\bAsbestos\s*\n\s*Assumed\s*\n\s*positive\b",
+        "Asbestos Assumed positive",
+        "asbestos_assumed_positive",
+        re.IGNORECASE,
+    ),
+    (
+        r"\bAsbestos\s*\n\s*Negative\b",
+        "Asbestos Negative",
+        "asbestos_negative",
+        re.IGNORECASE,
+    ),
+    (
+        r"\bAsbestos\s*\n\s*Positive\b",
+        "Asbestos Positive",
+        "asbestos_positive",
+        re.IGNORECASE,
+    ),
+    (
+        r"(Same\s+as)\s*\n\s*(34511-039-?\d+)",
+        r"\1 \2",
+        "same_as_sample_ref",
+        re.IGNORECASE,
+    ),
+    (
+        r"\bAssumed\s*\n\s*positive\b",
+        "Assumed positive",
+        "assumed_positive",
+        re.IGNORECASE,
+    ),
+    (
+        r"\bNo\s*\n\s*access\b",
+        "No access",
+        "no_access",
+        re.IGNORECASE,
+    ),
+    (
+        r"\bN/?A\s*\n\s*\(negative\)",
+        "N/A (negative)",
+        "na_negative",
+        re.IGNORECASE,
+    ),
+    (
+        r"\bNot\s*\n\s*sampled\b",
+        "Not sampled",
+        "not_sampled",
+        re.IGNORECASE,
+    ),
+    (
+        r"(\d{5})\s*\n\s*-\s*\n\s*(\d{3})\s*\n\s*-\s*\n\s*(\d{3})",
+        r"\1-\2-\3",
+        "split_sample_number",
+        re.IGNORECASE,
+    ),
+)
+
+
+def normalize_docling_text(text: str) -> str:
+    """Normalize line-broken Docling values before LLM extraction.
+
+    Args:
+        text: Raw Docling text content.
+
+    Returns:
+        Text with targeted line-break fixes applied.
+    """
+    if not text:
+        return text
+
+    normalized = text
+    fix_counts: Dict[str, int] = {}
+    total_fixes = 0
+
+    for pattern, replacement, fix_name, flags in _NORMALIZATION_RULES:
+        normalized, count = re.subn(pattern, replacement, normalized, flags=flags)
+        if count > 0:
+            fix_counts[fix_name] = count
+            total_fixes += count
+
+    if total_fixes > 0:
+        logger.info(
+            "Docling normalization applied {total_fixes} fixes: {fix_counts}",
+            total_fixes=total_fixes,
+            fix_counts=fix_counts,
+        )
+
+    return normalized

--- a/open_notebook/extractors/orchestrator.py
+++ b/open_notebook/extractors/orchestrator.py
@@ -34,6 +34,7 @@ from open_notebook.extractors.document_structure import (
     _PAGE_PATTERN,
     _page_num_from_match,
 )
+from open_notebook.extractors.normalizers.content import normalize_docling_text
 from open_notebook.extractors.page_tagger import (
     PageTaggingResult,
     SectionTaxonomy,
@@ -784,7 +785,7 @@ async def orchestrate_extraction(state: dict, config: RunnableConfig) -> dict:
     building inventory is available.
     """
     source: Source = state["source"]
-    content = source.full_text or ""
+    content = normalize_docling_text(source.full_text or "")
     inventory: BuildingInventory = state["building_inventory"]
     page_tags: Optional[PageTaggingResult] = state.get("page_tags")
     doc_meta: Optional[DocumentMeta] = state.get("document_metadata")

--- a/open_notebook/graphs/acm_extraction.py
+++ b/open_notebook/graphs/acm_extraction.py
@@ -53,6 +53,7 @@ from open_notebook.extractors.metadata_extractor import (
     auto_populate_site_config,
     extract_document_metadata,
 )
+from open_notebook.extractors.normalizers.content import normalize_docling_text
 from open_notebook.extractors.normalizers.enums import normalize_enum_value
 from open_notebook.extractors.orchestrator import (
     OrchestratorStats,
@@ -1021,7 +1022,7 @@ async def orchestrate_with_logging(state: dict, config: RunnableConfig) -> dict:
 async def prepare_context(state: dict, config: RunnableConfig) -> dict:
     """Prepare extraction context and chunk content if needed."""
     source: Source = state["source"]
-    content = source.full_text or ""
+    content = normalize_docling_text(source.full_text or "")
     pl = _get_pipeline_logger(state)
     agui = _get_agui_emitter(state)
 

--- a/tests/test_acm_api.py
+++ b/tests/test_acm_api.py
@@ -706,3 +706,104 @@ class TestACMRecordResponseClassificationFields:
         assert record["classification_confidence"] == 0.9
         assert record["classification_method"] == "pattern"
         assert record["classification_override"] is False
+
+
+class TestRawTableEndpoint:
+    """Test suite for GET /api/acm/jobs/{source_id}/raw-tables endpoint."""
+
+    @patch("api.routers.acm.ACMTableSection.get_by_source", new_callable=AsyncMock)
+    @patch("open_notebook.domain.notebook.Source.get", new_callable=AsyncMock)
+    def test_raw_table_prefers_mineru_sections(
+        self,
+        mock_get_source,
+        mock_get_sections,
+        client,
+    ):
+        """Endpoint should return MinerU table rows when raw_html is present."""
+        section = MagicMock()
+        section.id = "acm_table_section:1"
+        section.source_id = "source:abc"
+        section.page_start = 4
+        section.page_end = 4
+        section.table_type = "mineru_html"
+        section.raw_html = "<table><tr><td>Sample</td></tr></table>"
+        section.raw_text = "Sample"
+        section.building_name = "B001 Main Building"
+
+        mock_get_sections.return_value = [section]
+
+        response = client.get("/api/acm/jobs/source:abc/raw-tables")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert len(payload) == 1
+        assert payload[0]["table_type"] == "mineru_html"
+        assert payload[0]["raw_html"] == "<table><tr><td>Sample</td></tr></table>"
+        mock_get_source.assert_not_awaited()
+
+    @patch("api.routers.acm.ACMTableSection.get_by_source", new_callable=AsyncMock)
+    @patch("open_notebook.domain.notebook.Source.get", new_callable=AsyncMock)
+    def test_raw_table_returns_section_raw_text_rows(
+        self,
+        mock_get_source,
+        mock_get_sections,
+        client,
+    ):
+        """Endpoint should return existing acm_table_section raw_text rows."""
+        section = MagicMock()
+        section.id = "acm_table_section:2"
+        section.source_id = "source:abc"
+        section.page_start = 2
+        section.page_end = 3
+        section.table_type = "register"
+        section.raw_html = None
+        section.raw_text = "--- Page 2 ---\n| Col1 | Col2 |"
+        section.building_name = "B001 Main Building"
+
+        mock_get_sections.return_value = [section]
+
+        response = client.get("/api/acm/jobs/source:abc/raw-tables")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert len(payload) == 1
+        assert payload[0]["table_type"] == "register"
+        assert "| Col1 | Col2 |" in payload[0]["raw_text"]
+        mock_get_source.assert_not_awaited()
+
+    @patch("api.routers.acm.ACMTableSection.get_by_source", new_callable=AsyncMock)
+    @patch("open_notebook.domain.notebook.Source.get", new_callable=AsyncMock)
+    def test_raw_table_falls_back_to_docling_markdown(
+        self,
+        mock_get_source,
+        mock_get_sections,
+        client,
+    ):
+        """Endpoint should parse markdown table blocks when MinerU data is absent."""
+        section_without_html = MagicMock()
+        section_without_html.raw_html = None
+        section_without_html.raw_text = None
+        mock_get_sections.return_value = [section_without_html]
+
+        source = MagicMock()
+        source.full_text = (
+            "<!-- Page 1 -->\n"
+            "| Sample No | Result |\n"
+            "| --- | --- |\n"
+            "| 34511-039001 | Positive |\n\n"
+            "<!-- Page 2 -->\n"
+            "| Sample No | Result |\n"
+            "| --- | --- |\n"
+            "| - | Assumed positive |\n"
+        )
+        mock_get_source.return_value = source
+
+        response = client.get("/api/acm/jobs/source:abc/raw-tables")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert len(payload) == 2
+        assert payload[0]["table_type"] == "docling_markdown"
+        assert payload[0]["page_start"] == 1
+        assert payload[1]["page_start"] == 2
+        assert "| 34511-039001 | Positive |" in payload[0]["raw_text"]

--- a/tests/test_normalize_content.py
+++ b/tests/test_normalize_content.py
@@ -1,0 +1,98 @@
+"""Tests for Docling content normalization (E21-S4)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from open_notebook.extractors.normalizers.content import normalize_docling_text
+
+
+class TestNormalizeContent:
+    """Unit tests for normalize_docling_text."""
+
+    def test_normalize_content_fixes_split_values(self):
+        """Split values should be re-joined for extraction prompts."""
+        raw_text = (
+            "Sample No: Same as\n"
+            "34511-039001\n"
+            "Hazard: Asbestos\n"
+            "Assumed\n"
+            "positive\n"
+            "Result: Assumed\n"
+            "positive\n"
+            "Access: No\n"
+            "access\n"
+            "Status: N/A\n"
+            "(negative)"
+        )
+
+        normalized = normalize_docling_text(raw_text)
+
+        assert "Same as 34511-039001" in normalized
+        assert "Asbestos Assumed positive" in normalized
+        assert "Assumed positive" in normalized
+        assert "No access" in normalized
+        assert "N/A (negative)" in normalized
+
+    def test_normalize_content_collapses_split_sample_number(self):
+        """Multi-line sample numbers should be collapsed into one token."""
+        raw_text = "34511\n-\n039\n-\n001"
+
+        normalized = normalize_docling_text(raw_text)
+
+        assert "34511-039-001" in normalized
+
+    def test_normalize_content_keeps_clean_text_unchanged(self):
+        """Already clean text should be returned as-is."""
+        raw_text = "Same as 34511-039001\nAssumed positive\nNo access\nN/A (negative)"
+
+        assert normalize_docling_text(raw_text) == raw_text
+
+
+class TestPrepareContextNormalization:
+    """Integration tests for graph preflight normalization."""
+
+    @pytest.mark.asyncio
+    async def test_prepare_context_normalize_content_before_chunking(self):
+        """prepare_context should normalize Docling text before preprocessing."""
+        from open_notebook.graphs.acm_extraction import prepare_context
+
+        source = MagicMock()
+        source.id = "source:test"
+        source.title = "Test School"
+        source.full_text = "Same as\n34511-039001"
+
+        state = {"source": source}
+        config = MagicMock()
+
+        with (
+            patch(
+                "open_notebook.graphs.acm_extraction.normalize_docling_text",
+                return_value="Same as 34511-039001",
+            ) as mock_normalize,
+            patch(
+                "open_notebook.graphs.acm_extraction.log_extraction_preview"
+            ) as _mock_preview,
+            patch(
+                "open_notebook.graphs.acm_extraction.dump_content_to_file"
+            ) as _mock_dump,
+            patch(
+                "open_notebook.graphs.acm_extraction._preprocess_acm_content",
+                return_value=(
+                    "processed-content",
+                    {
+                        "acm_indicators_found": 0,
+                        "no_asbestos_found": 0,
+                    },
+                ),
+            ) as _mock_preprocess,
+            patch(
+                "open_notebook.graphs.acm_extraction._chunk_content",
+                return_value=[{"content": "processed-content", "page_number": 1}],
+            ) as _mock_chunk,
+        ):
+            result = await prepare_context(state, config)
+
+        mock_normalize.assert_called_once_with("Same as\n34511-039001")
+        assert result["content"] == "processed-content"
+        assert len(result["chunks"]) == 1

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -618,6 +618,47 @@ class TestOrchestrateExtraction:
         assert ctx.school_name == "Springfield Primary School"
 
     @pytest.mark.asyncio
+    async def test_orchestrator_normalize_content_before_extraction(self):
+        """Orchestrator should normalize Docling content before building extraction."""
+        source = MagicMock()
+        source.id = "source:test"
+        source.full_text = "Same as\n34511-039001"
+
+        inventory = _make_inventory(
+            [
+                _make_building(
+                    "B00A", "Storage Shed", 10, 10, BuildingComplexity.SIMPLE
+                ),
+            ]
+        )
+        tags = _make_page_tags([(10, 4, 0.9)])
+
+        state = {
+            "source": source,
+            "building_inventory": inventory,
+            "page_tags": tags,
+            "document_metadata": None,
+            "start_time": 0.0,
+        }
+
+        with (
+            patch(
+                "open_notebook.extractors.orchestrator.normalize_docling_text",
+                return_value="Same as 34511-039001",
+            ) as mock_normalize,
+            patch(
+                "open_notebook.extractors.orchestrator._extract_buildings_parallel",
+                new_callable=AsyncMock,
+                return_value=[],
+            ) as mock_parallel,
+        ):
+            result = await orchestrate_extraction(state, MagicMock())
+
+        mock_normalize.assert_called_once_with("Same as\n34511-039001")
+        assert mock_parallel.await_args.args[1] == "Same as 34511-039001"
+        assert result["content"] == "Same as 34511-039001"
+
+    @pytest.mark.asyncio
     async def test_legacy_fallback_not_triggered(self):
         """When inventory is present, orchestrator should be used (not legacy)."""
         state = {"building_inventory": _make_inventory()}
@@ -991,15 +1032,20 @@ class TestRegexYieldCheck:
             )
         ]
 
-        with patch(
-            "open_notebook.extractors.orchestrator._regex_extract_simple_building",
-            return_value=[],
-        ), patch(
-            "open_notebook.extractors.orchestrator._llm_extract_building",
-            new_callable=AsyncMock,
-            return_value=mock_records,
-        ) as mock_llm:
-            records, stats = await extract_building(plan, "Some building content here", {})
+        with (
+            patch(
+                "open_notebook.extractors.orchestrator._regex_extract_simple_building",
+                return_value=[],
+            ),
+            patch(
+                "open_notebook.extractors.orchestrator._llm_extract_building",
+                new_callable=AsyncMock,
+                return_value=mock_records,
+            ) as mock_llm,
+        ):
+            records, stats = await extract_building(
+                plan, "Some building content here", {}
+            )
 
         mock_llm.assert_awaited_once()
         assert stats.strategy_used == "regex_escalated_to_llm"
@@ -1022,13 +1068,16 @@ class TestRegexYieldCheck:
             for i in range(3)
         ]
 
-        with patch(
-            "open_notebook.extractors.orchestrator._regex_extract_simple_building",
-            return_value=regex_records,
-        ), patch(
-            "open_notebook.extractors.orchestrator._llm_extract_building",
-            new_callable=AsyncMock,
-        ) as mock_llm:
+        with (
+            patch(
+                "open_notebook.extractors.orchestrator._regex_extract_simple_building",
+                return_value=regex_records,
+            ),
+            patch(
+                "open_notebook.extractors.orchestrator._llm_extract_building",
+                new_callable=AsyncMock,
+            ) as mock_llm,
+        ):
             records, stats = await extract_building(plan, "content", {})
 
         mock_llm.assert_not_awaited()
@@ -1051,14 +1100,17 @@ class TestRegexYieldCheck:
             )
         ]
 
-        with patch(
-            "open_notebook.extractors.orchestrator._regex_extract_simple_building",
-            return_value=[],
-        ), patch(
-            "open_notebook.extractors.orchestrator._llm_extract_building",
-            new_callable=AsyncMock,
-            return_value=mock_records,
-        ) as mock_llm:
+        with (
+            patch(
+                "open_notebook.extractors.orchestrator._regex_extract_simple_building",
+                return_value=[],
+            ),
+            patch(
+                "open_notebook.extractors.orchestrator._llm_extract_building",
+                new_callable=AsyncMock,
+                return_value=mock_records,
+            ) as mock_llm,
+        ):
             records, stats = await extract_building(plan, "Non-empty content here", {})
 
         mock_llm.assert_awaited_once()
@@ -1071,13 +1123,16 @@ class TestRegexYieldCheck:
 
         plan = self._make_plan(estimate=None)
 
-        with patch(
-            "open_notebook.extractors.orchestrator._regex_extract_simple_building",
-            return_value=[],
-        ), patch(
-            "open_notebook.extractors.orchestrator._llm_extract_building",
-            new_callable=AsyncMock,
-        ) as mock_llm:
+        with (
+            patch(
+                "open_notebook.extractors.orchestrator._regex_extract_simple_building",
+                return_value=[],
+            ),
+            patch(
+                "open_notebook.extractors.orchestrator._llm_extract_building",
+                new_callable=AsyncMock,
+            ) as mock_llm,
+        ):
             records, stats = await extract_building(plan, "   ", {})
 
         mock_llm.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Add a backend raw table preview endpoint at `GET /api/acm/jobs/{source_id}/raw-tables` with fallback priority: MinerU HTML -> existing `acm_table_section.raw_text` -> parsed Docling markdown tables.
- Add Docling content normalization for split-value patterns (e.g., `Same as\n34511-039...`, `Assumed\npositive`, split sample numbers) and wire it into both extraction paths before LLM prompt input.
- Add tests for raw-table endpoint behavior and normalization integration, and update sprint artifacts for E21-S4 completion.

## Testing
- `uv run pytest tests/ -k "table_section or raw_table or normalize_content" -v`
- `uv run pytest tests/ -k "raw_table or normalize_content" -v`

## Validation Notes
- Broadmeadows extraction remained `17/31` after two attempts (target `>=28/31` not met).
- Alexander extracted `52` records in this run (historical baseline `54`).
- Raw table endpoint returns populated table payload for Broadmeadows.