### PR TITLE
feat(jobs-page): MCS11 frontend phases 3.3, 3.4, 5.2, 5.3

### DIFF
--- a/frontend/src/app/(dashboard)/jobs/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/jobs/[id]/page.tsx
@@ -13,10 +13,7 @@ import { JobOverviewTab } from '@/components/jobs/JobOverviewTab'
 import { JobContentPanel } from '@/components/jobs/JobContentPanel'
 import { JobCrudChatPanel } from '@/components/jobs/JobCrudChatPanel'
 import { BuildingGrid } from '@/components/acm/BuildingGrid'
-import {
-  BuildingTabFilter,
-  getRecordBuildingTabId,
-} from '@/components/acm/BuildingTabFilter'
+import { BuildingTabStrip } from '@/components/acm/BuildingTabStrip'
 import { ACMGrid, type ACMGridRef } from '@/components/acm/ACMGrid'
 import { ColumnVisibilityPicker } from '@/components/acm/ColumnVisibilityPicker'
 import { ACMRecordDialog } from '@/components/acm/ACMRecordDialog'
@@ -30,7 +27,8 @@ import { useSource } from '@/lib/hooks/use-sources'
 import { useBuildings } from '@/lib/hooks/useBuildings'
 import { useJobBuildings } from '@/lib/hooks/useJobBuildings'
 import { useV3BuildingStream } from '@/lib/hooks/useV3BuildingStream'
-import { useFieldSchema, useValidationSummary, useBulkFix } from '@/lib/hooks/useACMItems'
+import { useACMItems, useFieldSchema, useValidationSummary, useBulkFix } from '@/lib/hooks/useACMItems'
+import { useBuildingStore } from '@/lib/stores/buildingStore'
 import { useACMStats, useDeleteACMRecord } from '@/lib/hooks/use-acm'
 import { BulkOperationsBar } from '@/components/acm/BulkOperationsBar'
 import { Input } from '@/components/ui/input'
@@ -63,7 +61,7 @@ function JobDetailPageContent({ sourceId }: { sourceId: string }) {
   const router = useRouter()
   const queryClient = useQueryClient()
   const [activeTab, setActiveTab] = useState('overview')
-  const [selectedBuilding, setSelectedBuilding] = useState<string | null>(null)
+  const { selectedBuildingId: selectedBuilding, setSelectedBuilding } = useBuildingStore()
   const [chatExpanded, setChatExpanded] = useState(false)
   const [mobileChatOpen, setMobileChatOpen] = useState(false)
 
@@ -159,10 +157,19 @@ function JobDetailPageContent({ sourceId }: { sourceId: string }) {
     : jobBuildingsData
   const buildings = useMemo(() => buildingsData?.buildings ?? [], [buildingsData])
 
+  // MCS11 Phase 3.3: Per-building ACM items query (server-side filtered)
+  const { data: buildingRecordsData, refetch: refetchBuildingRecords } = useACMItems(
+    sourceId, selectedBuilding, { isExtracting: isStreaming || panelPhase === 'extracting' }
+  )
+  const displayRecords = selectedBuilding
+    ? (buildingRecordsData?.records ?? [])
+    : records
+
   // MCS11: Refetch records when SSE stream signals save complete
   useEffect(() => {
     if (!isStreaming && sseOperationId && panelPhase !== 'extracting') {
       void refetchRecords()
+      void refetchBuildingRecords()
       void queryClient.invalidateQueries({ queryKey: ['job-buildings', sourceId] })
       void queryClient.invalidateQueries({ queryKey: ['buildings', 'v3', sourceId] })
       void queryClient.invalidateQueries({ queryKey: ['acm-stats', sourceId] })
@@ -240,8 +247,9 @@ function JobDetailPageContent({ sourceId }: { sourceId: string }) {
       setDeleteDialogOpen(false)
       setDeletingRecord(null)
       void refetchRecords()
+      void refetchBuildingRecords()
     }
-  }, [deletingRecord, deleteRecordMutation, sourceId, refetchRecords])
+  }, [deletingRecord, deleteRecordMutation, sourceId, refetchRecords, refetchBuildingRecords])
 
   const handleRowClick = useCallback((record: ACMRecord) => {
     setDetailRecord(record)
@@ -256,28 +264,7 @@ function JobDetailPageContent({ sourceId }: { sourceId: string }) {
 
   useEffect(() => {
     setSelectedBuilding(null)
-  }, [sourceId])
-
-  useEffect(() => {
-    if (!selectedBuilding) {
-      return
-    }
-
-    const buildingExists = records.some(
-      (record) => getRecordBuildingTabId(record) === selectedBuilding
-    )
-    if (!buildingExists) {
-      setSelectedBuilding(null)
-    }
-  }, [records, selectedBuilding])
-
-  // Filter records by selected building for the ACM Records tab
-  const filteredRecords = useMemo(() => {
-    if (!selectedBuilding) return records
-    return records.filter(
-      (record) => getRecordBuildingTabId(record) === selectedBuilding
-    )
-  }, [records, selectedBuilding])
+  }, [sourceId, setSelectedBuilding])
 
   // Compute missing fields % and extraction quality score from actual record data
 
@@ -396,6 +383,10 @@ function JobDetailPageContent({ sourceId }: { sourceId: string }) {
                     missingFieldsPercent={missingFieldsPercent}
                     extractionQualityScore={extractionQualityScore}
                     onReExtract={handleReExtract}
+                    validationSummary={validationSummary}
+                    onBulkFix={() => bulkFixMutation.mutate({ sourceId })}
+                    isBulkFixing={bulkFixMutation.isPending}
+                    onNavigateToRecords={() => setActiveTab('records')}
                   />
                 </TabsContent>
 
@@ -420,16 +411,16 @@ function JobDetailPageContent({ sourceId }: { sourceId: string }) {
                   className="m-0 h-full overflow-auto p-4 sm:p-6"
                 >
                   <Card className="rounded-xl shadow-sm">
+                    <BuildingTabStrip
+                      buildings={buildings}
+                      isLoading={isLoadingBuildings}
+                      selectedBuildingId={selectedBuilding}
+                      onSelect={setSelectedBuilding}
+                      validationSummary={validationSummary}
+                    />
                     <CardContent className="space-y-4 p-4 sm:p-6">
-                      {/* Building filter + toolbar row */}
+                      {/* Toolbar row */}
                       <div className="flex flex-wrap items-center gap-2">
-                        <div className="flex-1 min-w-0">
-                          <BuildingTabFilter
-                            records={records}
-                            selectedBuilding={selectedBuilding}
-                            onBuildingChange={setSelectedBuilding}
-                          />
-                        </div>
                         {/* MCS11 Phase 3: Quick text search */}
                         <Input
                           placeholder="Search records..."
@@ -511,12 +502,12 @@ function JobDetailPageContent({ sourceId }: { sourceId: string }) {
                           sourceId={sourceId}
                           selectedRecords={selectedRecords}
                           onClearSelection={() => setSelectedRecords([])}
-                          onValidationRefresh={() => void refetchRecords()}
+                          onValidationRefresh={() => { void refetchRecords(); void refetchBuildingRecords() }}
                           schema={fieldSchema ?? null}
                         />
                       )}
 
-                      {(isStreaming || panelPhase === 'extracting') && filteredRecords.length === 0 ? (
+                      {(isStreaming || panelPhase === 'extracting') && displayRecords.length === 0 ? (
                         <div className="flex flex-col items-center justify-center py-16 text-center">
                           <div className="h-3 w-3 rounded-full bg-blue-500 animate-pulse mb-4" />
                           <p className="text-sm font-medium text-muted-foreground">
@@ -529,7 +520,7 @@ function JobDetailPageContent({ sourceId }: { sourceId: string }) {
                       ) : (
                         <ACMGrid
                           ref={gridRef}
-                          records={filteredRecords}
+                          records={displayRecords}
                           onEdit={handleEditRecord}
                           onDelete={handleDeleteRecord}
                           onRowClick={handleRowClick}

--- a/frontend/src/components/acm/ACMGrid.tsx
+++ b/frontend/src/components/acm/ACMGrid.tsx
@@ -237,6 +237,12 @@ export const ACMGrid = forwardRef<ACMGridRef, ACMGridProps>(function ACMGrid(
       if (params.data?.id && params.data.id === selectedRecordId) {
         classes.push('acm-row-selected')
       }
+      const vs = params.data?.validation_status
+      if (vs === 'invalid' || vs === 'failed_correction') {
+        classes.push('acm-row-error')
+      } else if (vs === 'corrected') {
+        classes.push('acm-row-corrected')
+      }
       return classes.length > 0 ? classes.join(' ') : undefined
     },
     [selectedRecordId]
@@ -671,6 +677,22 @@ export const ACMGrid = forwardRef<ACMGridRef, ACMGridProps>(function ACMGrid(
           0%, 100% { border-left-color: hsl(var(--primary) / 0.3); }
           50% { border-left-color: hsl(var(--primary)); }
         }
+        /* Validation error row highlighting */
+        .ag-theme-alpine .acm-row-error {
+          background-color: hsl(0 84% 60% / 0.08) !important;
+          border-left: 3px solid hsl(0 84% 60% / 0.5) !important;
+        }
+        .dark .ag-theme-alpine .acm-row-error {
+          background-color: hsl(0 84% 60% / 0.12) !important;
+        }
+        /* Auto-corrected row highlighting */
+        .ag-theme-alpine .acm-row-corrected {
+          background-color: hsl(45 93% 47% / 0.08) !important;
+          border-left: 3px solid hsl(45 93% 47% / 0.5) !important;
+        }
+        .dark .ag-theme-alpine .acm-row-corrected {
+          background-color: hsl(45 93% 47% / 0.12) !important;
+        }
       `}</style>
       <AgGridReact<ACMGridRecord>
         ref={gridRef}
@@ -710,6 +732,16 @@ export const ACMGrid = forwardRef<ACMGridRef, ACMGridProps>(function ACMGrid(
         <span>E to edit</span>
         <span>Space to expand/collapse</span>
         <span>? for all shortcuts</span>
+      </div>
+      <div className="text-xs text-muted-foreground mt-1 flex items-center gap-4">
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block h-2.5 w-2.5 rounded-sm border-l-2 border-red-500 bg-red-500/10" />
+          Validation errors
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block h-2.5 w-2.5 rounded-sm border-l-2 border-amber-500 bg-amber-500/10" />
+          Auto-corrected
+        </span>
       </div>
 
       {/* Provenance viewer panel */}

--- a/frontend/src/components/acm/BuildingTabStrip.tsx
+++ b/frontend/src/components/acm/BuildingTabStrip.tsx
@@ -1,0 +1,144 @@
+'use client'
+
+import { useRef } from 'react'
+import { Skeleton } from '@/components/ui/skeleton'
+import { useBuildingStore } from '@/lib/stores/buildingStore'
+import type { BuildingRecord } from '@/lib/types/building'
+import type { BuildingStreamStatus } from '@/lib/stores/buildingStore'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export interface BuildingTabStripProps {
+  buildings: BuildingRecord[]
+  isLoading: boolean
+  selectedBuildingId: string | null
+  onSelect: (id: string | null) => void
+  validationSummary: { buildings: Array<{ building_id: string; error_count: number }> } | null | undefined
+}
+
+export function BuildingTabStrip({
+  buildings,
+  isLoading,
+  selectedBuildingId,
+  onSelect,
+  validationSummary,
+}: BuildingTabStripProps) {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const { buildingStatus } = useBuildingStore()
+
+  const errorMap = new Map<string, number>(
+    (validationSummary?.buildings ?? []).map((b) => [b.building_id, b.error_count])
+  )
+
+  const scroll = (dir: 'left' | 'right') => {
+    scrollRef.current?.scrollBy({ left: dir === 'left' ? -200 : 200, behavior: 'smooth' })
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 px-4 py-2 border-b shrink-0 bg-muted/20">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-9 w-36 rounded-md" />
+        ))}
+      </div>
+    )
+  }
+
+  if (buildings.length === 0) return null
+
+  const streamBadge = (status: BuildingStreamStatus | undefined) => {
+    if (!status) return null
+    const classes: Record<BuildingStreamStatus, string> = {
+      detected: 'bg-blue-400',
+      extracting: 'bg-blue-500',
+      validating: 'bg-yellow-500',
+      saving: 'bg-purple-500',
+      complete: 'bg-green-500',
+      error: 'bg-red-500',
+    }
+    return <span className={cn('inline-block h-2 w-2 rounded-full shrink-0', classes[status])} />
+  }
+
+  const totalRecordCount = buildings.reduce((sum, b) => sum + b.record_count, 0)
+
+  return (
+    <div className="flex items-center border-b shrink-0 bg-muted/20">
+      <button
+        type="button"
+        onClick={() => scroll('left')}
+        className="shrink-0 px-1.5 py-2 text-muted-foreground hover:text-foreground"
+        aria-label="Scroll tabs left"
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </button>
+      <div
+        ref={scrollRef}
+        className="flex-1 flex items-center gap-1 overflow-x-auto scrollbar-none py-1.5"
+        style={{ scrollbarWidth: 'none' }}
+      >
+        {/* "All Records" tab */}
+        <button
+          type="button"
+          onClick={() => onSelect(null)}
+          className={cn(
+            'flex items-center gap-2 px-3 py-1.5 rounded-md text-sm whitespace-nowrap transition-colors shrink-0',
+            selectedBuildingId === null
+              ? 'bg-primary text-primary-foreground shadow-sm'
+              : 'hover:bg-muted text-muted-foreground hover:text-foreground'
+          )}
+        >
+          <span className="font-medium">All Records</span>
+          <span className={cn(
+            'text-xs tabular-nums',
+            selectedBuildingId === null ? 'text-primary-foreground/70' : 'text-muted-foreground'
+          )}>
+            {totalRecordCount}
+          </span>
+        </button>
+
+        {buildings.map((b) => {
+          const isSelected = b.id === selectedBuildingId
+          const errorCount = errorMap.get(b.id) ?? 0
+          const status = buildingStatus.get(b.internal_id)
+          return (
+            <button
+              key={b.id}
+              type="button"
+              onClick={() => onSelect(b.id)}
+              className={cn(
+                'flex items-center gap-2 px-3 py-1.5 rounded-md text-sm whitespace-nowrap transition-colors shrink-0',
+                isSelected
+                  ? 'bg-primary text-primary-foreground shadow-sm'
+                  : 'hover:bg-muted text-muted-foreground hover:text-foreground'
+              )}
+            >
+              {streamBadge(status)}
+              <span className="font-medium truncate max-w-40">
+                {b.building_name ?? b.building_code ?? b.internal_id}
+              </span>
+              <span className={cn(
+                'text-xs tabular-nums',
+                isSelected ? 'text-primary-foreground/70' : 'text-muted-foreground'
+              )}>
+                {b.record_count}
+              </span>
+              {errorCount > 0 && (
+                <span className="text-xs bg-red-100 text-red-700 dark:bg-red-950/40 dark:text-red-400 px-1 py-0.5 rounded-full leading-none">
+                  {errorCount}
+                </span>
+              )}
+            </button>
+          )
+        })}
+      </div>
+      <button
+        type="button"
+        onClick={() => scroll('right')}
+        className="shrink-0 px-1.5 py-2 text-muted-foreground hover:text-foreground"
+        aria-label="Scroll tabs right"
+      >
+        <ChevronRight className="h-4 w-4" />
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/components/jobs/JobOverviewTab.tsx
+++ b/frontend/src/components/jobs/JobOverviewTab.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { useQuery } from '@tanstack/react-query'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { ClipboardList, Building2, Percent, Gauge, ArrowRight, RefreshCw, FileText, MapPin, Calendar, User } from 'lucide-react'
+import { ClipboardList, Building2, Percent, Gauge, ArrowRight, RefreshCw, FileText, MapPin, Calendar, User, AlertTriangle, CheckCircle2, Wrench } from 'lucide-react'
 import { acmApi } from '@/lib/api/acm'
 import type { SourceIntelligence } from '@/lib/types/intelligence'
 
@@ -24,6 +24,10 @@ interface JobOverviewTabProps {
   missingFieldsPercent?: number | null
   extractionQualityScore?: number | null
   onReExtract?: () => void
+  validationSummary?: { buildings: { building_id: string; error_count: number }[] } | null
+  onBulkFix?: () => void
+  isBulkFixing?: boolean
+  onNavigateToRecords?: () => void
 }
 
 export function JobOverviewTab({
@@ -34,8 +38,14 @@ export function JobOverviewTab({
   missingFieldsPercent,
   extractionQualityScore,
   onReExtract,
+  validationSummary,
+  onBulkFix,
+  isBulkFixing,
+  onNavigateToRecords,
 }: JobOverviewTabProps) {
   const statusLabel = reviewStatus ? (STATUS_LABELS[reviewStatus] ?? reviewStatus) : 'Published'
+  const totalErrors = validationSummary?.buildings?.reduce((sum, b) => sum + b.error_count, 0) ?? 0
+  const errorBuildingCount = validationSummary?.buildings?.filter(b => b.error_count > 0).length ?? 0
 
   const { data: intelligence } = useQuery<SourceIntelligence | null>({
     queryKey: ['source-intelligence', sourceId],
@@ -108,6 +118,54 @@ export function JobOverviewTab({
           </CardContent>
         </Card>
       </div>
+
+      {/* Validation Summary */}
+      {totalErrors > 0 && (
+        <Card className="rounded-xl shadow-sm border-red-200 dark:border-red-900/50">
+          <CardHeader className="pb-2 pt-4 px-4">
+            <CardTitle className="text-sm font-semibold flex items-center gap-2">
+              <AlertTriangle className="h-4 w-4 text-red-500" />
+              Validation Issues
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="px-4 pb-4">
+            <div className="flex items-center gap-6">
+              <div>
+                <p className="text-2xl font-bold text-red-600 dark:text-red-400">{totalErrors}</p>
+                <p className="text-xs text-muted-foreground">total errors across {errorBuildingCount} buildings</p>
+              </div>
+              <div className="flex gap-2 ml-auto">
+                {onBulkFix && (
+                  <Button size="sm" variant="outline" onClick={onBulkFix} disabled={isBulkFixing}>
+                    <Wrench className="h-3.5 w-3.5 mr-1.5" />
+                    Fix All
+                  </Button>
+                )}
+                {onNavigateToRecords && (
+                  <Button size="sm" variant="outline" onClick={onNavigateToRecords}>
+                    View Errors
+                    <ArrowRight className="h-3.5 w-3.5 ml-1.5" />
+                  </Button>
+                )}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {totalErrors === 0 && recordCount > 0 && (
+        <Card className="rounded-xl shadow-sm border-green-200 dark:border-green-900/50">
+          <CardHeader className="pb-2 pt-4 px-4">
+            <CardTitle className="text-sm font-semibold flex items-center gap-2">
+              <CheckCircle2 className="h-4 w-4 text-green-500" />
+              Validation Passed
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="px-4 pb-4">
+            <p className="text-sm text-muted-foreground">All {recordCount} records pass validation.</p>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Document Metadata (from intelligence API) */}
       {docMeta && (


### PR DESCRIPTION
## Summary

- **Phase 3.3**: Per-building ACM data loading — `useACMItems(sourceId, buildingId)` replaces client-side filtering of 500+ records with server-side queries
- **Phase 3.4**: `BuildingTabStrip` shared component — scrollable horizontal tabs with record count badges, validation error badges, and stream status indicators
- **Phase 5.2**: Error row highlighting in `ACMGrid` — red rows for invalid/failed_correction, amber for auto-corrected, with legend
- **Phase 5.3**: Validation summary card on Overview tab — error count, affected buildings, "Fix All" button, "View Errors" navigation
- Zustand `buildingStore` replaces local `useState` for persistent building tab selection

## Files Changed

| File | Change |
|------|--------|
| `frontend/src/components/acm/BuildingTabStrip.tsx` | **New** — shared tab strip extracted from source page pattern |
| `frontend/src/app/(dashboard)/jobs/[id]/page.tsx` | Per-building data wiring, tab strip, validation props |
| `frontend/src/components/acm/ACMGrid.tsx` | Error/corrected row CSS + legend |
| `frontend/src/components/jobs/JobOverviewTab.tsx` | Validation summary card with Fix All + View Errors |

## Test plan

- [ ] `npm run build` passes (verified)
- [ ] `npm run lint` passes (verified)
- [ ] Open `/jobs/{sourceId}`, click ACM Records tab — building tab strip visible with counts
- [ ] Select a building tab → grid shows only that building's records
- [ ] Select "All Records" tab → grid shows all records
- [ ] Building selection persists when switching between Overview/Buildings/ACM Records tabs
- [ ] Records with `validation_status: 'invalid'` show red row highlight
- [ ] Records with `validation_status: 'corrected'` show amber row highlight
- [ ] Overview tab shows validation summary card when errors exist
- [ ] "Fix All" button triggers bulk fix mutation
- [ ] "View Errors" button switches to ACM Records tab

🤖 Generated with [Claude Code](https://claude.ai/code)