### PR TITLE
feat(chat): Active tab context + mobile fix + input polish

### DIFF
--- a/frontend/src/app/(dashboard)/jobs/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/jobs/[id]/page.tsx
@@ -632,6 +632,7 @@ function JobDetailPageContent({ sourceId }: { sourceId: string }) {
                 <UnifiedChatPanel
                   sourceId={sourceId}
                   hasAcmData={hasAcmData}
+                  activeTab={activeTab}
                 />
               </div>
             )}
@@ -649,7 +650,7 @@ function JobDetailPageContent({ sourceId }: { sourceId: string }) {
         </Button>
 
         <Sheet open={mobileChatOpen} onOpenChange={setMobileChatOpen}>
-          <SheetContent side="right" className="w-full p-0 sm:max-w-md">
+          <SheetContent side="right" className="w-full p-0 sm:max-w-md h-[85dvh]">
             <div className="flex h-full min-h-0 flex-col pt-10">
               <div className="border-b px-4 py-3 flex items-center gap-3">
                 <MessageSquare className="h-4 w-4 shrink-0" />
@@ -659,6 +660,7 @@ function JobDetailPageContent({ sourceId }: { sourceId: string }) {
                 <UnifiedChatPanel
                   sourceId={sourceId}
                   hasAcmData={hasAcmData}
+                  activeTab={activeTab}
                 />
               </div>
             </div>

--- a/frontend/src/components/chat/SmartChatInput.tsx
+++ b/frontend/src/components/chat/SmartChatInput.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, type KeyboardEvent } from 'react'
+import { useState, useRef, useEffect, type KeyboardEvent } from 'react'
 import { Textarea } from '@/components/ui/textarea'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
@@ -29,6 +29,15 @@ export function SmartChatInput({
 }: SmartChatInputProps) {
   const [input, setInput] = useState('')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const prevInProgress = useRef(false)
+
+  // Clear input when send starts (handles CopilotKit internal sends)
+  useEffect(() => {
+    if (inProgress && !prevInProgress.current) {
+      setInput('')
+    }
+    prevInProgress.current = inProgress
+  }, [inProgress])
 
   const keyHint = IS_MAC ? '\u2318+Enter' : 'Ctrl+Enter'
 

--- a/frontend/src/components/chat/SmartChatProvider.tsx
+++ b/frontend/src/components/chat/SmartChatProvider.tsx
@@ -6,6 +6,7 @@ interface SmartChatScope {
   sourceId?: string
   notebookId?: string
   hasAcmData: boolean
+  activeTab?: string
 }
 
 const SmartChatContext = createContext<SmartChatScope>({
@@ -25,9 +26,10 @@ export function SmartChatProvider({
   sourceId,
   notebookId,
   hasAcmData,
+  activeTab,
 }: SmartChatProviderProps) {
   return (
-    <SmartChatContext.Provider value={{ sourceId, notebookId, hasAcmData }}>
+    <SmartChatContext.Provider value={{ sourceId, notebookId, hasAcmData, activeTab }}>
       {children}
     </SmartChatContext.Provider>
   )

--- a/frontend/src/components/chat/UnifiedChatPanel.tsx
+++ b/frontend/src/components/chat/UnifiedChatPanel.tsx
@@ -13,13 +13,13 @@ import { SessionDropdown } from './SessionDropdown'
 import { HITLApprovalCard } from './renderers/HITLApprovalCard'
 import { useChatSessionStore } from '@/lib/stores/chatSessionStore'
 import { cn } from '@/lib/utils'
-import { TableProperties } from 'lucide-react'
 
 interface UnifiedChatPanelProps {
   sourceId?: string
   notebookId?: string
   hasAcmData?: boolean
   sessionId?: string
+  activeTab?: string
   className?: string
 }
 
@@ -71,6 +71,7 @@ export function UnifiedChatPanel({
   notebookId,
   hasAcmData = false,
   sessionId,
+  activeTab,
   className,
 }: UnifiedChatPanelProps) {
   return (
@@ -80,6 +81,7 @@ export function UnifiedChatPanel({
         notebookId={notebookId}
         hasAcmData={hasAcmData}
         sessionId={sessionId}
+        activeTab={activeTab}
         className={className}
       />
     </UnifiedChatErrorBoundary>
@@ -91,6 +93,7 @@ function UnifiedChatPanelContent({
   notebookId,
   hasAcmData = false,
   sessionId: sessionIdProp,
+  activeTab,
   className,
 }: UnifiedChatPanelProps) {
   const { activeSessionId, fetchSessions } = useChatSessionStore()
@@ -171,6 +174,7 @@ function UnifiedChatPanelContent({
       sourceId={sourceId}
       notebookId={notebookId}
       hasAcmData={hasAcmData}
+      activeTab={activeTab}
     >
       <UnifiedToolRenderers />
       <div className={cn('flex flex-col h-full', className)}>
@@ -206,25 +210,7 @@ function UnifiedChatPanelContent({
           />
         </div>
 
-        {/* ACM toggle badge */}
-        {hasAcmData && (
-          <div className="px-4 py-2 border-t flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => setIncludeAcmContext(!includeAcmContext)}
-              aria-label={`Toggle ACM data context: currently ${includeAcmContext ? 'on' : 'off'}`}
-              className={cn(
-                'inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-                includeAcmContext
-                  ? 'border-transparent bg-primary text-primary-foreground hover:bg-primary/80'
-                  : 'border-input bg-background text-foreground hover:bg-accent hover:text-accent-foreground'
-              )}
-            >
-              <TableProperties className="h-3 w-3" />
-              ACM Data {includeAcmContext ? 'ON' : 'OFF'}
-            </button>
-          </div>
-        )}
+        {/* ACM toggle is in SmartChatInput — no duplicate badge needed */}
       </div>
     </SmartChatProvider>
   )

--- a/frontend/src/components/chat/UnifiedToolRenderers.tsx
+++ b/frontend/src/components/chat/UnifiedToolRenderers.tsx
@@ -233,9 +233,9 @@ export function UnifiedToolRenderers() {
               <span className="inline-flex items-center rounded-md bg-amber-100 dark:bg-amber-900/50 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300">{String(parsed.operation)} Preview</span>
               <span className="text-[10px] font-mono text-muted-foreground">#{String(parsed.operation_id)}</span>
             </div>
-            {parsed.record_id && <div><span className="text-muted-foreground">Record:</span> <span className="font-mono">{String(parsed.record_id)}</span></div>}
-            {parsed.field && <div><span className="text-muted-foreground">Field:</span> <span className="font-semibold">{String(parsed.field)}</span> → <span className="text-green-700 dark:text-green-400 font-semibold">{String(parsed.new_value)}</span></div>}
-            {parsed.reason && <p className="text-muted-foreground italic">{String(parsed.reason)}</p>}
+            {!!parsed.record_id && <div><span className="text-muted-foreground">Record:</span> <span className="font-mono">{String(parsed.record_id)}</span></div>}
+            {!!parsed.field && <div><span className="text-muted-foreground">Field:</span> <span className="font-semibold">{String(parsed.field)}</span> → <span className="text-green-700 dark:text-green-400 font-semibold">{String(parsed.new_value)}</span></div>}
+            {!!parsed.reason && <p className="text-muted-foreground italic">{String(parsed.reason)}</p>}
             <p className="text-amber-600 dark:text-amber-400 text-[10px]">Awaiting approval via interrupt dialog...</p>
           </div>
         </ToolStepItem>
@@ -260,8 +260,8 @@ export function UnifiedToolRenderers() {
               <span className="text-[10px] font-mono text-muted-foreground">#{String(parsed.operation_id)}</span>
             </div>
             <div><span className="text-muted-foreground">Affected:</span> <span className="font-semibold">{String(parsed.affected_count)} records</span></div>
-            {parsed.field && <div><span className="text-muted-foreground">Field:</span> <span className="font-semibold">{String(parsed.field)}</span> → <span className="text-green-700 dark:text-green-400 font-semibold">{String(parsed.new_value)}</span></div>}
-            {parsed.reason && <p className="text-muted-foreground italic">{String(parsed.reason)}</p>}
+            {!!parsed.field && <div><span className="text-muted-foreground">Field:</span> <span className="font-semibold">{String(parsed.field)}</span> → <span className="text-green-700 dark:text-green-400 font-semibold">{String(parsed.new_value)}</span></div>}
+            {!!parsed.reason && <p className="text-muted-foreground italic">{String(parsed.reason)}</p>}
             <p className="text-amber-600 dark:text-amber-400 text-[10px]">Awaiting approval via interrupt dialog...</p>
           </div>
         </ToolStepItem>

--- a/frontend/src/components/chat/renderers/ToolStepItem.tsx
+++ b/frontend/src/components/chat/renderers/ToolStepItem.tsx
@@ -17,7 +17,6 @@ const TOOL_LABELS: Record<string, string> = {
   list_acm_buildings: 'Loading buildings',
   semantic_search_acm: 'Semantic search',
   search_documents: 'Searching documents',
-  search_documents: 'Searching documents',
   search_documents_vector: 'Searching documents',
   text_search_documents: 'Text search',
   search_documents_text: 'Text search',


### PR DESCRIPTION
## Summary
- **Active tab context**: `SmartChatProvider` now accepts `activeTab`, passed from jobs page for tab-aware chat suggestions
- **Mobile Sheet fix**: `h-[85dvh]` on SheetContent prevents iOS keyboard clipping
- **Input clear-on-send**: `SmartChatInput` clears when `inProgress` fires (handles CopilotKit internal sends)
- **Remove duplicate ACM toggle**: Bottom badge removed (toggle already in SmartChatInput)
- **Fix duplicate label**: Deduplicated `search_documents` entry in ToolStepItem labels

## Test plan
- [x] `npx next lint` — clean (pre-existing warnings only)
- [x] Backend: 57 tests pass
- [ ] Verify activeTab is passed to chat panel on jobs page
- [ ] Verify mobile Sheet height on 375x812 viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)