### PR TITLE
feat(auth): JWT authentication + user management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,7 +94,17 @@ API_URL=http://localhost:5055
 
 # SECURITY
 # Set this to protect your Open Notebook instance with a password (for public hosting)
+# Legacy shared password mode (fallback). Unset to use per-user JWT auth.
 # OPEN_NOTEBOOK_PASSWORD=
+
+# --- Per-User Authentication (JWT mode) ---
+# JWT signing secret (generate with: openssl rand -hex 32)
+# ACM_JWT_SECRET=change-me-to-random-64-char-hex
+
+# Initial admin account (used by: uv run python -m commands.create_admin)
+# ACM_ADMIN_EMAIL=admin@example.com
+# ACM_ADMIN_USERNAME=admin
+# ACM_ADMIN_PASSWORD=change-me-on-first-login
 
 # OPENAI
 # OPENAI_API_KEY=

--- a/api/auth.py
+++ b/api/auth.py
@@ -1,45 +1,69 @@
+"""
+Dual-mode authentication middleware for ACM-AI.
+
+Resolution order:
+1. If OPEN_NOTEBOOK_PASSWORD is set -> legacy shared-password mode (backward compat)
+2. Else if ACM_JWT_SECRET is set   -> per-user JWT auth mode
+3. Else                            -> no auth (dev mode, unprotected)
+"""
+
 import os
 from typing import Optional
 
-from fastapi import HTTPException, Request
+from fastapi import HTTPException
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from loguru import logger
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
 from starlette.responses import JSONResponse
 
+from api.auth_service import decode_access_token, get_user_by_id
 
-class PasswordAuthMiddleware(BaseHTTPMiddleware):
-    """
-    Middleware to check password authentication for all API requests.
-    Only active when OPEN_NOTEBOOK_PASSWORD environment variable is set.
-    """
+
+class AuthMiddleware(BaseHTTPMiddleware):
+    """Unified auth middleware supporting legacy password and JWT modes."""
 
     def __init__(self, app, excluded_paths: Optional[list] = None):
         super().__init__(app)
-        self.password = os.environ.get("OPEN_NOTEBOOK_PASSWORD")
-        self.excluded_paths = excluded_paths or [
-            "/",
-            "/health",
-            "/docs",
-            "/openapi.json",
-            "/redoc",
-        ]
+        self.legacy_password = os.environ.get("OPEN_NOTEBOOK_PASSWORD")
+        self.jwt_secret = os.environ.get("ACM_JWT_SECRET")
+        self.excluded_paths = excluded_paths or []
+
+    def _is_excluded(self, path: str) -> bool:
+        """Check if path is in the excluded list or matches a prefix."""
+        for excluded in self.excluded_paths:
+            if excluded.endswith("*"):
+                if path.startswith(excluded[:-1]):
+                    return True
+            elif path == excluded:
+                return True
+        return False
 
     async def dispatch(self, request: Request, call_next):
-        # Skip authentication if no password is set
-        if not self.password:
+        path = request.url.path
+
+        # Skip for excluded paths
+        if self._is_excluded(path):
             return await call_next(request)
 
-        # Skip authentication for excluded paths
-        if request.url.path in self.excluded_paths:
-            return await call_next(request)
-
-        # Skip authentication for CORS preflight requests (OPTIONS)
+        # Skip CORS preflight
         if request.method == "OPTIONS":
             return await call_next(request)
 
-        # Check authorization header
-        auth_header = request.headers.get("Authorization")
+        # Mode 1: Legacy shared password
+        if self.legacy_password:
+            return await self._legacy_auth(request, call_next)
 
+        # Mode 2: JWT per-user auth
+        if self.jwt_secret:
+            return await self._jwt_auth(request, call_next)
+
+        # Mode 3: No auth configured — allow all
+        return await call_next(request)
+
+    async def _legacy_auth(self, request: Request, call_next):
+        """Original shared-password authentication."""
+        auth_header = request.headers.get("Authorization")
         if not auth_header:
             return JSONResponse(
                 status_code=401,
@@ -47,11 +71,10 @@ class PasswordAuthMiddleware(BaseHTTPMiddleware):
                 headers={"WWW-Authenticate": "Bearer"},
             )
 
-        # Expected format: "Bearer {password}"
         try:
             scheme, credentials = auth_header.split(" ", 1)
             if scheme.lower() != "bearer":
-                raise ValueError("Invalid authentication scheme")
+                raise ValueError("Invalid scheme")
         except ValueError:
             return JSONResponse(
                 status_code=401,
@@ -59,50 +82,80 @@ class PasswordAuthMiddleware(BaseHTTPMiddleware):
                 headers={"WWW-Authenticate": "Bearer"},
             )
 
-        # Check password
-        if credentials != self.password:
+        if credentials != self.legacy_password:
             return JSONResponse(
                 status_code=401,
                 content={"detail": "Invalid password"},
                 headers={"WWW-Authenticate": "Bearer"},
             )
 
-        # Password is correct, proceed with the request
-        response = await call_next(request)
-        return response
+        return await call_next(request)
+
+    async def _jwt_auth(self, request: Request, call_next):
+        """JWT-based per-user authentication."""
+        auth_header = request.headers.get("Authorization")
+        if not auth_header:
+            return JSONResponse(
+                status_code=401,
+                content={"detail": "Missing authorization header"},
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+        try:
+            scheme, token = auth_header.split(" ", 1)
+            if scheme.lower() != "bearer":
+                raise ValueError("Invalid scheme")
+        except ValueError:
+            return JSONResponse(
+                status_code=401,
+                content={"detail": "Invalid authorization header format"},
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+        # Decode JWT
+        payload = decode_access_token(token)
+        if not payload:
+            return JSONResponse(
+                status_code=401,
+                content={"detail": "Invalid or expired token"},
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+        # Verify user is still active (soft delete check)
+        user = await get_user_by_id(payload["sub"])
+        if not user or user.get("status") != "active":
+            return JSONResponse(
+                status_code=401,
+                content={"detail": "Account deactivated"},
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+        # Inject user into request state for downstream handlers
+        request.state.user = user
+        return await call_next(request)
 
 
-# Optional: HTTPBearer security scheme for OpenAPI documentation
+# Keep for backward compatibility (OpenAPI docs)
 security = HTTPBearer(auto_error=False)
 
 
 def check_api_password(
     credentials: Optional[HTTPAuthorizationCredentials] = None,
 ) -> bool:
-    """
-    Utility function to check API password.
-    Can be used as a dependency in individual routes if needed.
-    """
+    """Legacy utility for individual route password checks."""
     password = os.environ.get("OPEN_NOTEBOOK_PASSWORD")
-
-    # No password set, allow access
     if not password:
         return True
-
-    # No credentials provided
     if not credentials:
         raise HTTPException(
             status_code=401,
             detail="Missing authorization",
             headers={"WWW-Authenticate": "Bearer"},
         )
-
-    # Check password
     if credentials.credentials != password:
         raise HTTPException(
             status_code=401,
             detail="Invalid password",
             headers={"WWW-Authenticate": "Bearer"},
         )
-
     return True

--- a/api/auth_dependencies.py
+++ b/api/auth_dependencies.py
@@ -1,0 +1,54 @@
+"""
+FastAPI authentication dependencies.
+Use these as Depends() in route handlers to enforce auth.
+"""
+
+from typing import Any, Optional
+
+from fastapi import Depends, HTTPException, Request
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from api.auth_service import decode_access_token, get_user_by_id
+
+security = HTTPBearer(auto_error=False)
+
+
+async def get_current_user_optional(
+    request: Request,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+) -> Optional[dict[str, Any]]:
+    """Extract current user from JWT if present. Returns None if no auth.
+    Use this for endpoints that work with or without auth."""
+    # Check if user was injected by middleware (legacy or JWT mode)
+    if hasattr(request.state, "user") and request.state.user:
+        return request.state.user
+    # Fallback: try extracting from Authorization header directly
+    if not credentials:
+        return None
+    payload = decode_access_token(credentials.credentials)
+    if not payload:
+        return None
+    user = await get_user_by_id(payload["sub"])
+    if user and user.get("status") == "active":
+        return user
+    return None
+
+
+async def get_current_user(
+    request: Request,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+) -> dict[str, Any]:
+    """Extract and validate current user from JWT. Raises 401 if not authenticated."""
+    user = await get_current_user_optional(request, credentials)
+    if not user:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    return user
+
+
+async def require_admin(
+    user: dict[str, Any] = Depends(get_current_user),
+) -> dict[str, Any]:
+    """Require authenticated user with admin role. Raises 403 if not admin."""
+    if user.get("role") != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
+    return user

--- a/api/auth_service.py
+++ b/api/auth_service.py
@@ -1,0 +1,300 @@
+"""
+Authentication service for ACM-AI.
+Handles JWT token creation/validation and password hashing.
+"""
+
+import os
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+import bcrypt
+import jwt
+from loguru import logger
+
+from open_notebook.database.repository import db_connection, parse_record_ids
+
+JWT_ALGORITHM = "HS256"
+JWT_EXPIRY_HOURS = 24
+
+
+def _first_row(result: list) -> Optional[dict[str, Any]]:
+    """Extract the first row from a SurrealDB query result.
+
+    SurrealDB returns different shapes: CREATE returns a single dict,
+    SELECT returns a list of dicts. This normalizes both.
+    """
+    if not result:
+        return None
+    data = result[0]
+    if isinstance(data, dict):
+        return parse_record_ids(data)
+    if isinstance(data, list) and data:
+        return parse_record_ids(data[0])
+    return None
+
+
+def get_jwt_secret() -> str:
+    secret = os.environ.get("ACM_JWT_SECRET")
+    if not secret:
+        raise RuntimeError(
+            "ACM_JWT_SECRET is not set. Generate one with: openssl rand -hex 32"
+        )
+    return secret
+
+
+def hash_password(password: str) -> str:
+    return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return bcrypt.checkpw(
+        plain_password.encode("utf-8"), hashed_password.encode("utf-8")
+    )
+
+
+def validate_password_strength(password: str) -> tuple[bool, str]:
+    """Validate password meets minimum requirements: 8+ chars, mixed case, number."""
+    if len(password) < 8:
+        return False, "Password must be at least 8 characters"
+    if not re.search(r"[A-Z]", password):
+        return False, "Password must contain at least one uppercase letter"
+    if not re.search(r"[a-z]", password):
+        return False, "Password must contain at least one lowercase letter"
+    if not re.search(r"\d", password):
+        return False, "Password must contain at least one digit"
+    return True, ""
+
+
+def create_access_token(user_data: dict[str, Any]) -> str:
+    """Create a JWT access token for the given user."""
+    now = datetime.now(tz=timezone.utc)
+    payload = {
+        "sub": user_data["id"],
+        "email": user_data["email"],
+        "username": user_data.get("username", ""),
+        "role": user_data.get("role", "user"),
+        "name": user_data.get("name", ""),
+        "iat": now,
+        "exp": now + timedelta(hours=JWT_EXPIRY_HOURS),
+    }
+    return jwt.encode(payload, get_jwt_secret(), algorithm=JWT_ALGORITHM)
+
+
+def decode_access_token(token: str) -> Optional[dict[str, Any]]:
+    """Decode and validate a JWT access token. Returns None on failure."""
+    try:
+        payload = jwt.decode(
+            token, get_jwt_secret(), algorithms=[JWT_ALGORITHM]
+        )
+        return payload
+    except jwt.ExpiredSignatureError:
+        logger.debug("JWT token expired")
+        return None
+    except jwt.InvalidTokenError as e:
+        logger.debug(f"Invalid JWT token: {e}")
+        return None
+
+
+async def get_user_by_email(email: str) -> Optional[dict[str, Any]]:
+    """Fetch a user by email from SurrealDB."""
+    async with db_connection() as db:
+        result = await db.query(
+            "SELECT * FROM user WHERE email = $email LIMIT 1",
+            {"email": email},
+        )
+        return _first_row(result)
+
+
+async def get_user_by_id(user_id: str) -> Optional[dict[str, Any]]:
+    """Fetch a user by ID from SurrealDB."""
+    async with db_connection() as db:
+        result = await db.query(
+            "SELECT * FROM type::thing($id)",
+            {"id": user_id},
+        )
+        return _first_row(result)
+
+
+async def get_user_by_username(username: str) -> Optional[dict[str, Any]]:
+    """Fetch a user by username from SurrealDB."""
+    async with db_connection() as db:
+        result = await db.query(
+            "SELECT * FROM user WHERE username = $username LIMIT 1",
+            {"username": username},
+        )
+        return _first_row(result)
+
+
+async def authenticate_user(
+    email: str, password: str
+) -> Optional[dict[str, Any]]:
+    """Authenticate a user by email + password. Returns user dict or None."""
+    user = await get_user_by_email(email)
+    if not user:
+        logger.warning(f"auth.login email={email} status=failed reason=not_found")
+        return None
+    if user.get("status") != "active":
+        logger.warning(f"auth.login email={email} status=failed reason=inactive")
+        return None
+    if not verify_password(password, user["password_hash"]):
+        logger.warning(f"auth.login email={email} status=failed reason=bad_password")
+        return None
+
+    # Update last_login
+    async with db_connection() as db:
+        await db.query(
+            "UPDATE type::thing($id) SET last_login = time::now()",
+            {"id": user["id"]},
+        )
+
+    logger.info(f"auth.login email={email} status=success")
+    return user
+
+
+async def create_user(
+    email: str,
+    username: str,
+    password: str,
+    role: str = "user",
+    name: Optional[str] = None,
+) -> dict[str, Any]:
+    """Create a new user in SurrealDB."""
+    password_hash = hash_password(password)
+    async with db_connection() as db:
+        result = await db.query(
+            """CREATE user CONTENT {
+                email: $email,
+                username: $username,
+                password_hash: $password_hash,
+                role: $role,
+                name: $name,
+                status: 'active',
+                created_at: time::now(),
+                updated_at: time::now()
+            }""",
+            {
+                "email": email,
+                "username": username,
+                "password_hash": password_hash,
+                "role": role,
+                "name": name,
+            },
+        )
+        row = _first_row(result)
+        if row:
+            return row
+        raise RuntimeError("Failed to create user")
+
+
+async def list_users() -> list[dict[str, Any]]:
+    """List all users (admin function). Excludes password_hash."""
+    async with db_connection() as db:
+        result = await db.query(
+            "SELECT id, email, username, role, status, name, "
+            "created_at, updated_at, last_login FROM user ORDER BY created_at DESC"
+        )
+        if not result:
+            return []
+        # db.query() already unwraps to the statement result:
+        # SELECT multi-row → list of dicts, single row → [dict], 0 rows → []
+        if isinstance(result, dict):
+            return [parse_record_ids(result)]
+        return [parse_record_ids(r) for r in result]
+
+
+async def update_user(
+    user_id: str, updates: dict[str, Any]
+) -> Optional[dict[str, Any]]:
+    """Update user fields. Returns updated user or None."""
+    allowed_fields = {"role", "status", "name", "email", "username"}
+    filtered = {k: v for k, v in updates.items() if k in allowed_fields}
+    if not filtered:
+        return None
+
+    filtered["updated_at"] = "time::now()"
+    set_clauses = ", ".join(
+        f"{k} = time::now()" if v == "time::now()" else f"{k} = ${k}"
+        for k, v in filtered.items()
+    )
+    params = {k: v for k, v in filtered.items() if v != "time::now()"}
+    params["id"] = user_id
+
+    async with db_connection() as db:
+        result = await db.query(
+            f"UPDATE type::thing($id) SET {set_clauses}",
+            params,
+        )
+        return _first_row(result)
+
+
+async def reset_user_password(
+    user_id: str, new_password: str
+) -> bool:
+    """Admin: reset a user's password."""
+    password_hash = hash_password(new_password)
+    async with db_connection() as db:
+        result = await db.query(
+            "UPDATE type::thing($id) SET password_hash = $hash, updated_at = time::now()",
+            {"id": user_id, "hash": password_hash},
+        )
+        return _first_row(result) is not None
+
+
+async def change_password(
+    user_id: str, current_password: str, new_password: str
+) -> tuple[bool, str]:
+    """User: change own password. Validates current password first."""
+    user = await get_user_by_id(user_id)
+    if not user:
+        return False, "User not found"
+    if not verify_password(current_password, user["password_hash"]):
+        return False, "Current password is incorrect"
+
+    valid, msg = validate_password_strength(new_password)
+    if not valid:
+        return False, msg
+
+    password_hash = hash_password(new_password)
+    async with db_connection() as db:
+        await db.query(
+            "UPDATE type::thing($id) SET password_hash = $hash, updated_at = time::now()",
+            {"id": user_id, "hash": password_hash},
+        )
+    logger.info(f"auth.password_change user_id={user_id} status=success")
+    return True, ""
+
+
+async def has_any_users() -> bool:
+    """Check if any users exist in the database."""
+    async with db_connection() as db:
+        result = await db.query("SELECT count() FROM user GROUP ALL")
+        row = _first_row(result)
+        if row:
+            return row.get("count", 0) > 0
+    return False
+
+
+async def assign_legacy_data_to_admin(admin_id: str) -> int:
+    """Assign all unowned records to the admin user. Returns count of updated records."""
+    total = 0
+    async with db_connection() as db:
+        for table in ["source", "notebook", "acm_record", "building_record"]:
+            result = await db.query(
+                f"UPDATE {table} SET owner = type::thing($admin_id) "
+                f"WHERE owner IS NONE OR owner IS NULL",
+                {"admin_id": admin_id},
+            )
+            # db.query() already unwraps: UPDATE multi-row → list, single → dict
+            if not result:
+                rows = []
+            elif isinstance(result, dict):
+                rows = [result]
+            else:
+                rows = result
+            total += len(rows)
+            if rows:
+                logger.info(
+                    f"Assigned {len(rows)} {table} records to admin {admin_id}"
+                )
+    return total

--- a/api/main.py
+++ b/api/main.py
@@ -37,7 +37,7 @@ logger.add(
     diagnose=True,
 )
 
-from api.auth import PasswordAuthMiddleware
+from api.auth import AuthMiddleware
 from api.model_provisioning import run_model_provisioning
 from open_notebook.observability.logfire_config import init_logfire
 
@@ -46,6 +46,7 @@ init_logfire()
 from api.routers import (
     a2a,
     acm,
+    admin,
     agui_extraction,
     auth,
     config,
@@ -165,20 +166,25 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-# Add password authentication middleware first
-# Exclude /api/auth/status and /api/config from authentication
+# Add authentication middleware (supports legacy password + JWT modes)
+# Excluded paths bypass auth entirely (public endpoints + SSE streams)
 app.add_middleware(
-    PasswordAuthMiddleware,
+    AuthMiddleware,
     excluded_paths=[
         "/",
         "/health",
+        "/health/ready",
         "/docs",
         "/openapi.json",
         "/redoc",
         "/api/auth/status",
+        "/api/auth/login",
         "/api/config",
         "/api/agui/chat",
         "/api/agui/crud-chat",
+        "/api/extraction-events/*",
+        "/api/acm/extract/events/*",
+        "/api/v3/stream/*",
         "/.well-known/agent.json",
     ],
 )
@@ -200,6 +206,7 @@ app.add_middleware(
 
 # Include routers
 app.include_router(auth.router, prefix="/api", tags=["auth"])
+app.include_router(admin.router, prefix="/api/auth", tags=["admin"])
 app.include_router(config.router, prefix="/api", tags=["config"])
 app.include_router(notebooks.router, prefix="/api", tags=["notebooks"])
 app.include_router(search.router, prefix="/api", tags=["search"])

--- a/api/routers/admin.py
+++ b/api/routers/admin.py
@@ -1,0 +1,193 @@
+"""
+Admin router for ACM-AI API.
+Provides user management endpoints (admin-only).
+"""
+
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from loguru import logger
+from pydantic import BaseModel, EmailStr
+
+from api.auth_dependencies import require_admin
+from api.auth_service import (
+    create_user,
+    get_user_by_email,
+    get_user_by_id,
+    get_user_by_username,
+    list_users,
+    reset_user_password,
+    update_user,
+    validate_password_strength,
+)
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+class CreateUserRequest(BaseModel):
+    email: EmailStr
+    username: str
+    password: str
+    role: str = "user"
+    name: Optional[str] = None
+
+
+class UpdateUserRequest(BaseModel):
+    role: Optional[str] = None
+    status: Optional[str] = None
+    name: Optional[str] = None
+
+
+class ResetPasswordRequest(BaseModel):
+    new_password: str
+
+
+@router.post("/users")
+async def admin_create_user(
+    request: CreateUserRequest,
+    admin: dict[str, Any] = Depends(require_admin),
+):
+    """Create a new user (admin only)."""
+    # Validate password
+    valid, msg = validate_password_strength(request.password)
+    if not valid:
+        raise HTTPException(status_code=400, detail=msg)
+
+    # Check for duplicate email
+    existing = await get_user_by_email(request.email)
+    if existing:
+        raise HTTPException(status_code=409, detail="Email already registered")
+
+    # Check for duplicate username
+    existing = await get_user_by_username(request.username)
+    if existing:
+        raise HTTPException(status_code=409, detail="Username already taken")
+
+    # Validate role
+    if request.role not in ("admin", "user"):
+        raise HTTPException(status_code=400, detail="Role must be 'admin' or 'user'")
+
+    user = await create_user(
+        email=request.email,
+        username=request.username,
+        password=request.password,
+        role=request.role,
+        name=request.name,
+    )
+
+    logger.info(
+        f"auth.admin action=create_user target={request.email} by={admin['email']}"
+    )
+
+    return {
+        "id": user["id"],
+        "email": user["email"],
+        "username": user["username"],
+        "role": user["role"],
+        "status": user["status"],
+        "name": user.get("name"),
+    }
+
+
+@router.get("/users")
+async def admin_list_users(
+    admin: dict[str, Any] = Depends(require_admin),
+):
+    """List all users (admin only)."""
+    users = await list_users()
+    return {"users": users, "total": len(users)}
+
+
+@router.patch("/users/{user_id}")
+async def admin_update_user(
+    user_id: str,
+    request: UpdateUserRequest,
+    admin: dict[str, Any] = Depends(require_admin),
+):
+    """Update a user's role or status (admin only)."""
+    # Resolve the full user ID if just the key part was provided
+    if ":" not in user_id:
+        user_id = f"user:{user_id}"
+
+    # Check user exists
+    target = await get_user_by_id(user_id)
+    if not target:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    # Validate role if provided
+    if request.role and request.role not in ("admin", "user"):
+        raise HTTPException(status_code=400, detail="Role must be 'admin' or 'user'")
+
+    # Validate status if provided
+    if request.status and request.status not in ("active", "inactive"):
+        raise HTTPException(
+            status_code=400, detail="Status must be 'active' or 'inactive'"
+        )
+
+    updates = request.model_dump(exclude_none=True)
+    if not updates:
+        raise HTTPException(status_code=400, detail="No updates provided")
+
+    updated = await update_user(user_id, updates)
+
+    logger.info(
+        f"auth.admin action=update_user target={user_id} updates={updates} by={admin['email']}"
+    )
+
+    return updated
+
+
+@router.post("/users/{user_id}/reset-password")
+async def admin_reset_password(
+    user_id: str,
+    request: ResetPasswordRequest,
+    admin: dict[str, Any] = Depends(require_admin),
+):
+    """Reset a user's password (admin only)."""
+    if ":" not in user_id:
+        user_id = f"user:{user_id}"
+
+    # Validate new password
+    valid, msg = validate_password_strength(request.new_password)
+    if not valid:
+        raise HTTPException(status_code=400, detail=msg)
+
+    target = await get_user_by_id(user_id)
+    if not target:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    success = await reset_user_password(user_id, request.new_password)
+    if not success:
+        raise HTTPException(status_code=500, detail="Failed to reset password")
+
+    logger.info(
+        f"auth.admin action=reset_password target={user_id} by={admin['email']}"
+    )
+
+    return {"message": f"Password reset for {target['email']}"}
+
+
+@router.delete("/users/{user_id}")
+async def admin_deactivate_user(
+    user_id: str,
+    admin: dict[str, Any] = Depends(require_admin),
+):
+    """Deactivate a user account (soft delete, admin only)."""
+    if ":" not in user_id:
+        user_id = f"user:{user_id}"
+
+    target = await get_user_by_id(user_id)
+    if not target:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    # Prevent self-deactivation
+    if target["id"] == admin["id"]:
+        raise HTTPException(status_code=400, detail="Cannot deactivate your own account")
+
+    updated = await update_user(user_id, {"status": "inactive"})
+
+    logger.info(
+        f"auth.admin action=deactivate_user target={user_id} by={admin['email']}"
+    )
+
+    return {"message": f"User {target['email']} deactivated", "user": updated}

--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -1,26 +1,124 @@
 """
-Authentication router for Open Notebook API.
-Provides endpoints to check authentication status.
+Authentication router for ACM-AI API.
+Provides login, profile, password change, and auth status endpoints.
 """
 
 import os
+from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+from loguru import logger
+from pydantic import BaseModel, EmailStr
+
+from api.auth_dependencies import get_current_user
+from api.auth_service import (
+    authenticate_user,
+    change_password,
+    create_access_token,
+    has_any_users,
+    validate_password_strength,
+)
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
+class LoginRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class LoginResponse(BaseModel):
+    token: str
+    user: dict[str, Any]
+
+
+class ChangePasswordRequest(BaseModel):
+    current_password: str
+    new_password: str
+
+
 @router.get("/status")
 async def get_auth_status():
-    """
-    Check if authentication is enabled.
-    Returns whether a password is required to access the API.
-    """
-    auth_enabled = bool(os.environ.get("OPEN_NOTEBOOK_PASSWORD"))
+    """Check if authentication is enabled and which mode is active."""
+    legacy_enabled = bool(os.environ.get("OPEN_NOTEBOOK_PASSWORD"))
+    jwt_enabled = bool(os.environ.get("ACM_JWT_SECRET"))
+    users_exist = False
+    if jwt_enabled:
+        try:
+            users_exist = await has_any_users()
+        except Exception:
+            pass
+
+    auth_enabled = legacy_enabled or (jwt_enabled and users_exist)
+    mode = "legacy" if legacy_enabled else ("jwt" if jwt_enabled else "none")
 
     return {
         "auth_enabled": auth_enabled,
+        "mode": mode,
         "message": "Authentication is required"
         if auth_enabled
         else "Authentication is disabled",
     }
+
+
+@router.post("/login")
+async def login(request: LoginRequest):
+    """Authenticate with email + password and receive a JWT token."""
+    user = await authenticate_user(request.email, request.password)
+    if not user:
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=401, detail="Invalid email or password")
+
+    token = create_access_token(user)
+
+    # Return user info without sensitive fields
+    safe_user = {
+        "id": user["id"],
+        "email": user["email"],
+        "username": user.get("username", ""),
+        "role": user.get("role", "user"),
+        "name": user.get("name", ""),
+    }
+
+    logger.info(f"auth.login email={request.email} status=success")
+    return {"token": token, "user": safe_user}
+
+
+@router.get("/me")
+async def get_me(user: dict[str, Any] = Depends(get_current_user)):
+    """Get current authenticated user's profile."""
+    return {
+        "id": user["id"],
+        "email": user["email"],
+        "username": user.get("username", ""),
+        "role": user.get("role", "user"),
+        "name": user.get("name", ""),
+        "status": user.get("status", "active"),
+        "last_login": user.get("last_login"),
+        "created_at": user.get("created_at"),
+    }
+
+
+@router.post("/change-password")
+async def change_user_password(
+    request: ChangePasswordRequest,
+    user: dict[str, Any] = Depends(get_current_user),
+):
+    """Change the current user's password."""
+    # Validate new password strength
+    valid, msg = validate_password_strength(request.new_password)
+    if not valid:
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=400, detail=msg)
+
+    success, error = await change_password(
+        user["id"], request.current_password, request.new_password
+    )
+    if not success:
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=400, detail=error)
+
+    return {"message": "Password changed successfully"}

--- a/api/routers/notebooks.py
+++ b/api/routers/notebooks.py
@@ -1,8 +1,9 @@
-from typing import List, Optional
+from typing import Any, List, Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from loguru import logger
 
+from api.auth_dependencies import get_current_user_optional
 from api.models import NotebookCreate, NotebookResponse, NotebookUpdate
 from open_notebook.database.repository import ensure_record_id, repo_query
 from open_notebook.domain.notebook import Notebook, Source
@@ -13,21 +14,31 @@ router = APIRouter()
 
 @router.get("/notebooks", response_model=List[NotebookResponse])
 async def get_notebooks(
+    request: Request,
     archived: Optional[bool] = Query(None, description="Filter by archived status"),
     order_by: str = Query("updated desc", description="Order by field and direction"),
+    user: Optional[dict[str, Any]] = Depends(get_current_user_optional),
 ):
     """Get all notebooks with optional filtering and ordering."""
     try:
+        # Build owner filter for per-user data isolation
+        owner_filter = ""
+        params: dict[str, Any] = {}
+        if user and user.get("role") != "admin":
+            owner_filter = "WHERE owner = type::thing($owner_id)"
+            params["owner_id"] = user["id"]
+
         # Build the query with counts
         query = f"""
             SELECT *,
             count(<-reference.in) as source_count,
             count(<-artifact.in) as note_count
             FROM notebook
+            {owner_filter}
             ORDER BY {order_by}
         """
 
-        result = await repo_query(query)
+        result = await repo_query(query, params if params else None)
 
         # Filter by archived status if specified
         if archived is not None:
@@ -54,12 +65,17 @@ async def get_notebooks(
 
 
 @router.post("/notebooks", response_model=NotebookResponse)
-async def create_notebook(notebook: NotebookCreate):
+async def create_notebook(
+    notebook: NotebookCreate,
+    request: Request,
+    user: Optional[dict[str, Any]] = Depends(get_current_user_optional),
+):
     """Create a new notebook."""
     try:
         new_notebook = Notebook(
             name=notebook.name,
             description=notebook.description,
+            owner=user["id"] if user else None,
         )
         await new_notebook.save()
 

--- a/api/routers/sources.py
+++ b/api/routers/sources.py
@@ -9,12 +9,14 @@ from fastapi import (
     Form,
     HTTPException,
     Query,
+    Request,
     UploadFile,
 )
 from fastapi.responses import FileResponse, Response
 from loguru import logger
 from surreal_commands import submit_command, wait_for_command
 
+from api.auth_dependencies import get_current_user_optional
 from api.command_service import CommandService
 from api.models import (
     AssetModel,
@@ -212,6 +214,7 @@ def parse_source_form_data(
 
 @router.get("/sources", response_model=List[SourceListResponse])
 async def get_sources(
+    request: Request,
     notebook_id: Optional[str] = Query(None, description="Filter by notebook ID"),
     limit: int = Query(
         50, ge=1, le=100, description="Number of sources to return (1-100)"
@@ -221,6 +224,7 @@ async def get_sources(
         "updated", description="Field to sort by (created or updated)"
     ),
     sort_order: str = Query("desc", description="Sort order (asc or desc)"),
+    user: Optional[dict] = Depends(get_current_user_optional),
 ):
     """Get sources with pagination and sorting support."""
     try:
@@ -263,6 +267,13 @@ async def get_sources(
                 },
             )
         else:
+            # Build owner filter for per-user data isolation
+            owner_filter = ""
+            query_params: dict[str, Any] = {"limit": limit, "offset": offset}
+            if user and user.get("role") != "admin":
+                owner_filter = "WHERE owner = type::thing($owner_id)"
+                query_params["owner_id"] = user["id"]
+
             # Query all sources - include command field
             query = f"""
                 SELECT id, asset, created, title, updated, topics, command, review_status,
@@ -270,10 +281,11 @@ async def get_sources(
                 ((SELECT VALUE id FROM source_embedding WHERE source = $parent.id LIMIT 1)) != NONE AS embedded,
                 (SELECT VALUE total_pages FROM source_intelligence WHERE source_id = $parent.id LIMIT 1)[0] OR 0 AS page_count
                 FROM source
+                {owner_filter}
                 {order_clause}
                 LIMIT $limit START $offset
             """
-            result = await repo_query(query, {"limit": limit, "offset": offset})
+            result = await repo_query(query, query_params)
 
         source_ids = [str(row["id"]) for row in result if row.get("id")]
         # SurrealDB record<source> fields need type::thing() for comparison.
@@ -521,9 +533,11 @@ async def get_sources(
 
 @router.post("/sources", response_model=SourceResponse)
 async def create_source(
+    request: Request,
     form_data: tuple[SourceCreate, Optional[UploadFile]] = Depends(
         parse_source_form_data
     ),
+    user: Optional[dict] = Depends(get_current_user_optional),
 ):
     """Create a new source with support for both JSON and multipart form data."""
     source_data, upload_file = form_data
@@ -602,6 +616,7 @@ async def create_source(
                 title=source_data.title or "Processing...",
                 topics=[],
                 review_status="extracting",
+                owner=user["id"] if user else None,
             )
             await source.save()
 
@@ -692,6 +707,7 @@ async def create_source(
                 source = Source(
                     title=source_data.title or "Processing...",
                     topics=[],
+                    owner=user["id"] if user else None,
                 )
                 await source.save()
 

--- a/commands/create_admin.py
+++ b/commands/create_admin.py
@@ -1,0 +1,83 @@
+"""
+Bootstrap script: Create the first admin user from environment variables.
+
+Usage:
+    uv run python -m commands.create_admin
+
+Reads from environment:
+    ACM_ADMIN_EMAIL    - Admin email address
+    ACM_ADMIN_USERNAME - Admin username
+    ACM_ADMIN_PASSWORD - Admin initial password
+
+Also assigns all existing unowned records (sources, notebooks, acm_items,
+acm_registers) to the admin user.
+"""
+
+import asyncio
+import os
+import sys
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from loguru import logger  # noqa: E402
+
+
+async def create_admin_user():
+    # Import after dotenv so DB connection works
+    from api.auth_service import (
+        assign_legacy_data_to_admin,
+        create_user,
+        get_user_by_email,
+        validate_password_strength,
+    )
+
+    email = os.environ.get("ACM_ADMIN_EMAIL")
+    username = os.environ.get("ACM_ADMIN_USERNAME", "admin")
+    password = os.environ.get("ACM_ADMIN_PASSWORD")
+
+    if not email or not password:
+        logger.error(
+            "ACM_ADMIN_EMAIL and ACM_ADMIN_PASSWORD must be set in .env"
+        )
+        sys.exit(1)
+
+    # Check if admin already exists
+    existing = await get_user_by_email(email)
+    if existing:
+        logger.info(f"Admin user already exists: {email} (id: {existing['id']})")
+        return existing
+
+    # Validate password
+    valid, msg = validate_password_strength(password)
+    if not valid:
+        logger.error(f"Password validation failed: {msg}")
+        sys.exit(1)
+
+    # Create admin
+    user = await create_user(
+        email=email,
+        username=username,
+        password=password,
+        role="admin",
+        name=username.capitalize(),
+    )
+    logger.info(f"Admin user created: {email} (id: {user['id']})")
+
+    # Assign legacy data
+    count = await assign_legacy_data_to_admin(user["id"])
+    if count > 0:
+        logger.info(f"Assigned {count} existing records to admin user")
+
+    return user
+
+
+def main():
+    result = asyncio.run(create_admin_user())
+    print(f"\nAdmin user ready: {result['email']} (id: {result['id']})")
+    print("You can now login at /login with these credentials.")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/sprint-artifacts/auth-implementation/requirements.md
+++ b/docs/sprint-artifacts/auth-implementation/requirements.md
@@ -1,0 +1,65 @@
+# User Authentication — Requirements (Interview Summary)
+
+**Date:** 2026-04-16
+**Branch:** feat/user-auth
+**Interviewer rounds:** 10/10
+
+## Decisions
+
+### Authentication Model
+- **Method:** Email + Password (per-user accounts)
+- **Registration:** Admin-only (no self-registration)
+- **Roles:** Admin + User (2-tier)
+
+### Session Management
+- **Token storage:** JWT in localStorage (current pattern), sent via Authorization header
+- **Token expiry:** 24 hours
+- **JWT signing:** HS256 with `ACM_JWT_SECRET` env var
+- **Password policy:** Standard (8+ chars, mixed case + number)
+
+### SurrealDB Architecture
+- **Auth layer:** Application-level only (FastAPI validates JWT, DB stays root-access)
+- **Fallback:** Keep `OPEN_NOTEBOOK_PASSWORD` as backward-compatible fallback
+- **Worker/LLM access:** Root DB access preserved for LangGraph, LangChain, worker processes
+
+### Data Isolation
+- **Scope:** Per-user data isolation (users see only their own data)
+- **Future:** Team-based isolation planned
+- **Owner tables:** source, notebook, acm_item, acm_register
+- **Legacy data:** Assigned to first admin user on migration
+- **Filtering:** Repository/query level with `current_user` context
+- **Admin bypass:** Admins see all data
+
+### Admin Capabilities
+- **Scope:** Essential admin API only (no admin UI in v1)
+- **Endpoints:** Create user, list users, update role/status, reset password, deactivate
+- **Bootstrap:** Seed script + env vars for first admin
+
+### Frontend
+- **Login page:** Upgrade existing form with new design + branding
+- **Route protection:** Next.js middleware.ts (server-side)
+- **User profile:** Sidebar avatar + dropdown (hide settings from non-admin users)
+- **Password change:** Self-service change-password dialog
+- **Force change on first login:** No
+
+### Security & Deployment
+- **Rate limiting:** None (simple for now)
+- **Account deactivation:** Soft delete + immediate session invalidation
+- **Audit logging:** Basic Python logger (auth events with IP)
+- **CORS:** Keep wildcard CORS with token in Authorization header
+- **Env template:** .env.example with placeholders
+- **SSE endpoints:** Stay public (no auth required)
+
+### First Admin
+- **Username:** demi
+- **Email:** demi.thathsara@silvatron.com
+- **Password:** (set in .env, never committed)
+
+## Non-Goals (explicitly out of scope)
+- OAuth / SSO / Magic link
+- Admin UI panel
+- Email notifications
+- 2FA / MFA
+- Rate limiting / brute force protection
+- Team/organization hierarchy
+- SurrealDB DEFINE ACCESS scoped auth

--- a/docs/sprint-artifacts/auth-implementation/tech-spec.md
+++ b/docs/sprint-artifacts/auth-implementation/tech-spec.md
@@ -1,0 +1,229 @@
+# User Authentication — Technical Specification
+
+**Date:** 2026-04-16
+**Branch:** feat/user-auth
+
+## Architecture
+
+```
+Browser (8502)                     FastAPI (5055)                    SurrealDB (8000)
+┌──────────────┐    JWT header    ┌──────────────────┐    root      ┌────────────┐
+│ Next.js App  │─────────────────▶│ AuthMiddleware   │─────────────▶│ user table │
+│              │                  │  ↓ validates JWT  │              │ source     │
+│ middleware.ts│ redirect /login  │  ↓ loads user     │              │ notebook   │
+│ auth-store   │◀─────────────────│  ↓ injects user   │              │ acm_item   │
+│ LoginForm    │                  │                    │              │ acm_register│
+└──────────────┘                  └──────────────────┘              └────────────┘
+                                       │
+                                  LangGraph/Worker ──────── root access (unchanged)
+```
+
+## Auth Resolution Order
+
+```
+1. If OPEN_NOTEBOOK_PASSWORD is set → old shared-password mode (backward compat)
+2. Else if user table has records   → per-user JWT auth mode
+3. Else                             → no auth (dev mode, unprotected)
+```
+
+## Database Schema
+
+### Migration: DEFINE TABLE user
+
+```surrealql
+-- Migration XX: User authentication table
+DEFINE TABLE IF NOT EXISTS user SCHEMAFULL;
+
+DEFINE FIELD username ON user TYPE string;
+DEFINE FIELD email ON user TYPE string ASSERT string::is::email($value);
+DEFINE FIELD password_hash ON user TYPE string;
+DEFINE FIELD role ON user TYPE string ASSERT $value IN ['admin', 'user'] DEFAULT 'user';
+DEFINE FIELD status ON user TYPE string ASSERT $value IN ['active', 'inactive'] DEFAULT 'active';
+DEFINE FIELD name ON user TYPE option<string>;
+DEFINE FIELD created_at ON user TYPE datetime DEFAULT time::now();
+DEFINE FIELD updated_at ON user TYPE datetime DEFAULT time::now();
+DEFINE FIELD last_login ON user TYPE option<datetime>;
+
+DEFINE INDEX idx_user_email ON user FIELDS email UNIQUE;
+DEFINE INDEX idx_user_username ON user FIELDS username UNIQUE;
+```
+
+### Migration: Add owner field to existing tables
+
+```surrealql
+-- Migration XX+1: Add owner field for per-user data isolation
+DEFINE FIELD IF NOT EXISTS owner ON TABLE source TYPE option<record<user>>;
+DEFINE FIELD IF NOT EXISTS owner ON TABLE notebook TYPE option<record<user>>;
+DEFINE FIELD IF NOT EXISTS owner ON TABLE acm_item TYPE option<record<user>>;
+DEFINE FIELD IF NOT EXISTS owner ON TABLE acm_register TYPE option<record<user>>;
+
+DEFINE INDEX IF NOT EXISTS idx_source_owner ON source FIELDS owner;
+DEFINE INDEX IF NOT EXISTS idx_notebook_owner ON notebook FIELDS owner;
+DEFINE INDEX IF NOT EXISTS idx_acm_item_owner ON acm_item FIELDS owner;
+DEFINE INDEX IF NOT EXISTS idx_acm_register_owner ON acm_register FIELDS owner;
+```
+
+## Backend API
+
+### New Dependencies
+- `PyJWT>=2.8.0` — JWT encode/decode
+- `passlib[bcrypt]>=1.7.4` — Password hashing (bcrypt)
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `api/auth_service.py` | JWT creation, password hashing, user validation |
+| `api/auth_dependencies.py` | FastAPI Depends() for get_current_user, require_admin |
+| `api/routers/auth.py` | Extended: login, me, change-password endpoints |
+| `api/routers/admin.py` | Admin user management endpoints |
+| `commands/create_admin.py` | CLI seed script for first admin |
+| `migrations/XX_user_auth.surrealql` | User table migration |
+| `migrations/XX_owner_fields.surrealql` | Owner field migration |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `api/main.py` | Replace PasswordAuthMiddleware with JWTAuthMiddleware |
+| `api/auth.py` | Refactor: dual-mode auth (legacy password OR JWT) |
+| `api/routers/sources.py` | Add `user = Depends(get_current_user)`, filter by owner |
+| `api/routers/notebooks.py` | Add owner filtering |
+| `api/routers/acm.py` | Add owner filtering |
+| `open_notebook/domain/notebook.py` | Add owner field to model |
+| `open_notebook/domain/base.py` | Handle owner RecordID conversion |
+
+### Endpoints
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/api/auth/login` | Public | Email + password login, returns JWT |
+| GET | `/api/auth/me` | JWT | Get current user profile |
+| POST | `/api/auth/change-password` | JWT | Change own password |
+| GET | `/api/auth/status` | Public | Check if auth is enabled (existing) |
+| POST | `/api/auth/admin/users` | Admin | Create new user |
+| GET | `/api/auth/admin/users` | Admin | List all users |
+| PATCH | `/api/auth/admin/users/{id}` | Admin | Update user role/status |
+| POST | `/api/auth/admin/users/{id}/reset-password` | Admin | Reset user password |
+
+### JWT Payload
+
+```json
+{
+  "sub": "user:abc123",
+  "email": "demi@silvatron.com",
+  "role": "admin",
+  "username": "demi",
+  "exp": 1713484800,
+  "iat": 1713398400
+}
+```
+
+### Auth Middleware Logic
+
+```python
+class JWTAuthMiddleware:
+    async def dispatch(self, request, call_next):
+        # 1. Check if OPEN_NOTEBOOK_PASSWORD mode
+        if self.legacy_password:
+            return self._legacy_check(request, call_next)
+        
+        # 2. Skip public endpoints
+        if self._is_public(request.url.path):
+            return await call_next(request)
+        
+        # 3. Validate JWT from Authorization header
+        token = self._extract_token(request)
+        user = self._validate_jwt(token)
+        
+        # 4. Check user status (soft delete check)
+        if user.status != 'active':
+            return JSONResponse(401, {"detail": "Account deactivated"})
+        
+        # 5. Inject user into request state
+        request.state.user = user
+        return await call_next(request)
+```
+
+## Frontend
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `frontend/src/middleware.ts` | Next.js route protection middleware |
+| `frontend/src/components/auth/ChangePasswordDialog.tsx` | Change password modal |
+| `frontend/src/components/auth/UserMenu.tsx` | Sidebar user avatar + dropdown |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `frontend/src/components/auth/LoginForm.tsx` | Add email field, new branding |
+| `frontend/src/lib/stores/auth-store.ts` | Store user object, JWT with claims |
+| `frontend/src/lib/types/auth.ts` | Add User, LoginCredentials types |
+| `frontend/src/lib/hooks/use-auth.ts` | Return user object, update login flow |
+| `frontend/src/lib/api/client.ts` | No change needed (already sends Bearer) |
+| `frontend/src/components/layout/AppSidebar.tsx` | Add UserMenu, hide admin items for non-admins |
+| `frontend/src/app/(dashboard)/layout.tsx` | Simplify (middleware.ts handles redirect) |
+
+### Next.js Middleware
+
+```typescript
+// frontend/src/middleware.ts
+import { NextRequest, NextResponse } from 'next/server'
+
+const publicPaths = ['/login', '/_next', '/favicon.ico']
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl
+  
+  // Skip public paths
+  if (publicPaths.some(p => pathname.startsWith(p))) {
+    return NextResponse.next()
+  }
+  
+  // Check for token in cookie or localStorage-synced cookie
+  const token = request.cookies.get('acm_token')?.value
+  
+  if (!token) {
+    const loginUrl = new URL('/login', request.url)
+    loginUrl.searchParams.set('redirect', pathname)
+    return NextResponse.redirect(loginUrl)
+  }
+  
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/((?!api|_next/static|_next/image|.*\\.png$|.*\\.ico$).*)']
+}
+```
+
+## Environment Variables
+
+```bash
+# New in .env
+ACM_JWT_SECRET=<64-char-hex>          # JWT signing key
+ACM_ADMIN_EMAIL=demi.thathsara@silvatron.com
+ACM_ADMIN_PASSWORD=<initial-password>  # Used by seed script only
+ACM_ADMIN_USERNAME=demi
+
+# Existing (kept as fallback)
+# OPEN_NOTEBOOK_PASSWORD=              # Unset to use per-user auth
+```
+
+## Verification Checklist
+- [ ] `uv run pytest` passes
+- [ ] `uv run ruff check .` passes
+- [ ] `cd frontend && npm run build` passes
+- [ ] Login with email + password works
+- [ ] Admin can create new users via API
+- [ ] Non-admin cannot access admin endpoints
+- [ ] Users only see their own sources/notebooks
+- [ ] Admin sees all data
+- [ ] Change password works
+- [ ] Deactivated user cannot login
+- [ ] Legacy OPEN_NOTEBOOK_PASSWORD still works when set
+- [ ] SSE/extraction events work without auth
+- [ ] Existing LangGraph/worker processes unaffected

--- a/docs/sprint-artifacts/sprint-status.yaml
+++ b/docs/sprint-artifacts/sprint-status.yaml
@@ -1773,3 +1773,16 @@ pipeline-audit-2026-04-16:
     - docs/sprint-artifacts/reports/pipeline-analysis-2026-04-09.md
     - docs/sprint-artifacts/reports/extraction-test-2026-04-09.md
     - docs/sprint-artifacts/reports/full-audit-2026-04-09.md
+
+  # ─────────────────────────────────────────────────────
+  # Epic 39: User Authentication & Data Isolation (P0)
+  # Client-requested. Branch: feat/user-auth
+  # Goal: Replace shared-password auth with per-user JWT auth,
+  #   admin-only user management, per-user data isolation.
+  # Planning: docs/sprint-artifacts/auth-implementation/
+  # ─────────────────────────────────────────────────────
+  epic-39: in-progress
+  e39-s1-user-auth-backend: in-progress  # SurrealDB user table, JWT auth service, FastAPI middleware (dual-mode: legacy+JWT), auth router (login/me/change-password), admin router (CRUD users), seed script. Migrations 57-58.
+  e39-s2-user-auth-frontend: in-progress  # Login form upgrade (email+password), Next.js middleware.ts, auth store refactor (JWT), UserMenu, ChangePasswordDialog, sidebar integration.
+  e39-s3-data-isolation: in-progress  # Owner field on source/notebook/acm_record/building_record. Repository-level owner filtering. Admin bypasses filters.
+  e39-s4-verification-e2e: backlog  # pytest, ruff, frontend build, browser verification with Playwright.

--- a/frontend/src/app/(dashboard)/settings/users/loading.tsx
+++ b/frontend/src/app/(dashboard)/settings/users/loading.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { AppShell } from '@/components/layout/AppShell'
+import { Skeleton } from '@/components/ui/skeleton'
+
+export default function UsersSettingsLoading() {
+  return (
+    <AppShell>
+      <div className="flex-1 overflow-y-auto p-6" aria-busy="true">
+        <span className="sr-only" role="status">Loading user management</span>
+        <div className="max-w-4xl space-y-6">
+          <div className="flex items-center justify-between">
+            <Skeleton className="h-8 w-48" />
+            <Skeleton className="h-9 w-28" />
+          </div>
+
+          <div className="rounded-xl border">
+            <div className="flex gap-4 p-3 border-b">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-4 w-40" />
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-4 w-20" />
+              <Skeleton className="h-4 w-24" />
+            </div>
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="flex gap-4 p-3 border-b last:border-b-0">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-4 w-40" />
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-4 w-20" />
+                <Skeleton className="h-4 w-24" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </AppShell>
+  )
+}

--- a/frontend/src/app/(dashboard)/settings/users/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/users/page.tsx
@@ -1,0 +1,640 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { AppShell } from '@/components/layout/AppShell'
+import { ErrorBoundary } from '@/components/common/ErrorBoundary'
+import { PageErrorFallback } from '@/components/common/PageErrorFallback'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { ConfirmDialog } from '@/components/common/ConfirmDialog'
+import { apiClient } from '@/lib/api/client'
+import { useAuth } from '@/lib/hooks/use-auth'
+import { toast } from 'sonner'
+import {
+  Users,
+  Plus,
+  Pencil,
+  KeyRound,
+  UserX,
+  UserCheck,
+  Shield,
+  AlertCircle,
+} from 'lucide-react'
+
+interface UserRecord {
+  id: string
+  email: string
+  username: string
+  role: 'admin' | 'user'
+  status: 'active' | 'inactive'
+  name?: string
+  created_at?: string
+  last_login?: string
+}
+
+export default function UsersSettingsPage() {
+  return (
+    <ErrorBoundary
+      fallback={(props: { error?: Error; resetError: () => void }) => (
+        <PageErrorFallback {...props} pageName="User Management" reloadUrl="/settings/users" />
+      )}
+    >
+      <UsersContent />
+    </ErrorBoundary>
+  )
+}
+
+function UsersContent() {
+  const queryClient = useQueryClient()
+  const { user: currentUser } = useAuth()
+  const [createOpen, setCreateOpen] = useState(false)
+  const [editUser, setEditUser] = useState<UserRecord | null>(null)
+  const [resetPasswordUser, setResetPasswordUser] = useState<UserRecord | null>(null)
+  const [deactivateUser, setDeactivateUser] = useState<UserRecord | null>(null)
+  const [reactivateUser, setReactivateUser] = useState<UserRecord | null>(null)
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['admin-users'],
+    queryFn: async () => {
+      const res = await apiClient.get('/auth/admin/users')
+      return res.data as { users: UserRecord[]; total: number }
+    },
+  })
+
+  const users = data?.users ?? []
+
+  return (
+    <AppShell>
+      <div className="flex-1 overflow-y-auto">
+        <div className="p-6 max-w-4xl space-y-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-bold">User Management</h1>
+              <p className="text-sm text-muted-foreground mt-1">
+                Create and manage user accounts
+              </p>
+            </div>
+            <Button onClick={() => setCreateOpen(true)}>
+              <Plus className="h-4 w-4 mr-2" />
+              Add User
+            </Button>
+          </div>
+
+          <Card>
+            <CardHeader>
+              <div className="flex items-center gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+                  <Users className="h-5 w-5 text-primary" />
+                </div>
+                <div>
+                  <CardTitle>Users</CardTitle>
+                  <CardDescription>
+                    {data ? `${data.total} registered user${data.total !== 1 ? 's' : ''}` : 'Loading...'}
+                  </CardDescription>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {isLoading && (
+                <div className="text-sm text-muted-foreground py-8 text-center">Loading users...</div>
+              )}
+              {error && (
+                <div className="flex items-center gap-2 text-red-600 text-sm py-4">
+                  <AlertCircle className="h-4 w-4" />
+                  <span>Failed to load users. Make sure you have admin access.</span>
+                </div>
+              )}
+              {!isLoading && !error && users.length === 0 && (
+                <div className="text-sm text-muted-foreground py-8 text-center">No users found.</div>
+              )}
+              {users.length > 0 && (
+                <div className="space-y-1">
+                  {/* Header */}
+                  <div className="grid grid-cols-[1fr_1fr_80px_80px_140px] gap-3 px-3 py-2 text-xs font-medium text-muted-foreground border-b">
+                    <div>User</div>
+                    <div>Email</div>
+                    <div>Role</div>
+                    <div>Status</div>
+                    <div className="text-right">Actions</div>
+                  </div>
+                  {/* Rows */}
+                  {users.map((u) => (
+                    <div
+                      key={u.id}
+                      className="grid grid-cols-[1fr_1fr_80px_80px_140px] gap-3 px-3 py-2.5 items-center text-sm hover:bg-muted/50 rounded-md"
+                    >
+                      <div>
+                        <div className="font-medium flex items-center gap-1.5">
+                          {u.name || u.username}
+                          {u.id === currentUser?.id && (
+                            <Badge variant="outline" className="text-[10px] px-1 py-0">you</Badge>
+                          )}
+                        </div>
+                        <div className="text-xs text-muted-foreground">@{u.username}</div>
+                      </div>
+                      <div className="text-muted-foreground truncate">{u.email}</div>
+                      <div>
+                        <Badge variant={u.role === 'admin' ? 'default' : 'secondary'} className="text-xs">
+                          {u.role === 'admin' && <Shield className="h-3 w-3 mr-1" />}
+                          {u.role}
+                        </Badge>
+                      </div>
+                      <div>
+                        <Badge
+                          variant={u.status === 'active' ? 'outline' : 'destructive'}
+                          className="text-xs"
+                        >
+                          {u.status}
+                        </Badge>
+                      </div>
+                      <div className="flex items-center justify-end gap-1">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7"
+                          title="Edit user"
+                          onClick={() => setEditUser(u)}
+                        >
+                          <Pencil className="h-3.5 w-3.5" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7"
+                          title="Reset password"
+                          onClick={() => setResetPasswordUser(u)}
+                        >
+                          <KeyRound className="h-3.5 w-3.5" />
+                        </Button>
+                        {u.id !== currentUser?.id && (
+                          u.status === 'active' ? (
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-7 w-7 text-red-600 hover:text-red-700"
+                              title="Deactivate user"
+                              onClick={() => setDeactivateUser(u)}
+                            >
+                              <UserX className="h-3.5 w-3.5" />
+                            </Button>
+                          ) : (
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-7 w-7 text-green-600 hover:text-green-700"
+                              title="Reactivate user"
+                              onClick={() => setReactivateUser(u)}
+                            >
+                              <UserCheck className="h-3.5 w-3.5" />
+                            </Button>
+                          )
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      {/* Dialogs */}
+      <CreateUserDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onSuccess={() => queryClient.invalidateQueries({ queryKey: ['admin-users'] })}
+      />
+      <EditUserDialog
+        user={editUser}
+        onOpenChange={(open) => !open && setEditUser(null)}
+        onSuccess={() => queryClient.invalidateQueries({ queryKey: ['admin-users'] })}
+      />
+      <ResetPasswordDialog
+        user={resetPasswordUser}
+        onOpenChange={(open) => !open && setResetPasswordUser(null)}
+      />
+      <DeactivateDialog
+        user={deactivateUser}
+        onOpenChange={(open) => !open && setDeactivateUser(null)}
+        onSuccess={() => queryClient.invalidateQueries({ queryKey: ['admin-users'] })}
+      />
+      <ReactivateDialog
+        user={reactivateUser}
+        onOpenChange={(open) => !open && setReactivateUser(null)}
+        onSuccess={() => queryClient.invalidateQueries({ queryKey: ['admin-users'] })}
+      />
+    </AppShell>
+  )
+}
+
+// ─── Create User Dialog ──────────────────────────────────────────
+
+function CreateUserDialog({
+  open,
+  onOpenChange,
+  onSuccess,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSuccess: () => void
+}) {
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [role, setRole] = useState<'admin' | 'user'>('user')
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const res = await apiClient.post('/auth/admin/users', {
+        name: name || undefined,
+        email,
+        username,
+        password,
+        role,
+      })
+      return res.data
+    },
+    onSuccess: () => {
+      toast.success('User created successfully')
+      onOpenChange(false)
+      resetForm()
+      onSuccess()
+    },
+    onError: (err: { response?: { data?: { detail?: string } } }) => {
+      toast.error(err.response?.data?.detail || 'Failed to create user')
+    },
+  })
+
+  const resetForm = () => {
+    setName('')
+    setEmail('')
+    setUsername('')
+    setPassword('')
+    setRole('user')
+  }
+
+  const handleClose = (open: boolean) => {
+    if (!open) resetForm()
+    onOpenChange(open)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Create New User</DialogTitle>
+          <DialogDescription>Add a new user account to the system.</DialogDescription>
+        </DialogHeader>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            mutation.mutate()
+          }}
+          className="space-y-4"
+        >
+          <div className="space-y-1.5">
+            <label htmlFor="create-name" className="text-sm font-medium">Display Name</label>
+            <Input
+              id="create-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="John Doe"
+              disabled={mutation.isPending}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label htmlFor="create-email" className="text-sm font-medium">Email *</label>
+            <Input
+              id="create-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="user@example.com"
+              required
+              disabled={mutation.isPending}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label htmlFor="create-username" className="text-sm font-medium">Username *</label>
+            <Input
+              id="create-username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              placeholder="johndoe"
+              required
+              disabled={mutation.isPending}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label htmlFor="create-password" className="text-sm font-medium">Password *</label>
+            <Input
+              id="create-password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Min 8 chars, mixed case + number"
+              required
+              disabled={mutation.isPending}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium">Role</label>
+            <Select value={role} onValueChange={(v) => setRole(v as 'admin' | 'user')}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="user">User</SelectItem>
+                <SelectItem value="admin">Admin</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => handleClose(false)} disabled={mutation.isPending}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={mutation.isPending || !email.trim() || !username.trim() || !password.trim()}
+            >
+              {mutation.isPending ? 'Creating...' : 'Create User'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// ─── Edit User Dialog ────────────────────────────────────────────
+
+function EditUserDialog({
+  user,
+  onOpenChange,
+  onSuccess,
+}: {
+  user: UserRecord | null
+  onOpenChange: (open: boolean) => void
+  onSuccess: () => void
+}) {
+  const [role, setRole] = useState<'admin' | 'user'>('user')
+  const [name, setName] = useState('')
+  const open = !!user
+
+  useEffect(() => {
+    if (user) {
+      setRole(user.role)
+      setName(user.name || '')
+    }
+  }, [user])
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!user) return
+      const res = await apiClient.patch(`/auth/admin/users/${user.id}`, {
+        role,
+        name: name || undefined,
+      })
+      return res.data
+    },
+    onSuccess: () => {
+      toast.success('User updated successfully')
+      onOpenChange(false)
+      onSuccess()
+    },
+    onError: (err: { response?: { data?: { detail?: string } } }) => {
+      toast.error(err.response?.data?.detail || 'Failed to update user')
+    },
+  })
+
+  const handleClose = (open: boolean) => {
+    if (!open) {
+      setRole('user')
+      setName('')
+    }
+    onOpenChange(open)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Edit User</DialogTitle>
+          <DialogDescription>
+            Update details for {user?.email}
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            mutation.mutate()
+          }}
+          className="space-y-4"
+        >
+          <div className="space-y-1.5">
+            <label htmlFor="edit-name" className="text-sm font-medium">Display Name</label>
+            <Input
+              id="edit-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              disabled={mutation.isPending}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium">Role</label>
+            <Select value={role} onValueChange={(v) => setRole(v as 'admin' | 'user')}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="user">User</SelectItem>
+                <SelectItem value="admin">Admin</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => handleClose(false)} disabled={mutation.isPending}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={mutation.isPending}>
+              {mutation.isPending ? 'Saving...' : 'Save Changes'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// ─── Reset Password Dialog ───────────────────────────────────────
+
+function ResetPasswordDialog({
+  user,
+  onOpenChange,
+}: {
+  user: UserRecord | null
+  onOpenChange: (open: boolean) => void
+}) {
+  const [newPassword, setNewPassword] = useState('')
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!user) return
+      const res = await apiClient.post(`/auth/admin/users/${user.id}/reset-password`, {
+        new_password: newPassword,
+      })
+      return res.data
+    },
+    onSuccess: () => {
+      toast.success('Password reset successfully')
+      onOpenChange(false)
+      setNewPassword('')
+    },
+    onError: (err: { response?: { data?: { detail?: string } } }) => {
+      toast.error(err.response?.data?.detail || 'Failed to reset password')
+    },
+  })
+
+  const handleClose = (open: boolean) => {
+    if (!open) setNewPassword('')
+    onOpenChange(open)
+  }
+
+  return (
+    <Dialog open={!!user} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Reset Password</DialogTitle>
+          <DialogDescription>
+            Set a new password for {user?.email}
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            mutation.mutate()
+          }}
+          className="space-y-4"
+        >
+          <div className="space-y-1.5">
+            <label htmlFor="reset-password" className="text-sm font-medium">New Password</label>
+            <Input
+              id="reset-password"
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              placeholder="Min 8 chars, mixed case + number"
+              required
+              disabled={mutation.isPending}
+            />
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => handleClose(false)} disabled={mutation.isPending}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={mutation.isPending || !newPassword.trim()}>
+              {mutation.isPending ? 'Resetting...' : 'Reset Password'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// ─── Deactivate / Reactivate Dialogs ─────────────────────────────
+
+function DeactivateDialog({
+  user,
+  onOpenChange,
+  onSuccess,
+}: {
+  user: UserRecord | null
+  onOpenChange: (open: boolean) => void
+  onSuccess: () => void
+}) {
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!user) return
+      await apiClient.delete(`/auth/admin/users/${user.id}`)
+    },
+    onSuccess: () => {
+      toast.success('User deactivated')
+      onOpenChange(false)
+      onSuccess()
+    },
+    onError: (err: { response?: { data?: { detail?: string } } }) => {
+      toast.error(err.response?.data?.detail || 'Failed to deactivate user')
+    },
+  })
+
+  return (
+    <ConfirmDialog
+      open={!!user}
+      onOpenChange={onOpenChange}
+      title="Deactivate User"
+      description={`Are you sure you want to deactivate ${user?.email}? They will be immediately logged out and unable to sign in.`}
+      confirmText="Deactivate"
+      confirmVariant="destructive"
+      onConfirm={() => mutation.mutate()}
+      isLoading={mutation.isPending}
+    />
+  )
+}
+
+function ReactivateDialog({
+  user,
+  onOpenChange,
+  onSuccess,
+}: {
+  user: UserRecord | null
+  onOpenChange: (open: boolean) => void
+  onSuccess: () => void
+}) {
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!user) return
+      await apiClient.patch(`/auth/admin/users/${user.id}`, { status: 'active' })
+    },
+    onSuccess: () => {
+      toast.success('User reactivated')
+      onOpenChange(false)
+      onSuccess()
+    },
+    onError: (err: { response?: { data?: { detail?: string } } }) => {
+      toast.error(err.response?.data?.detail || 'Failed to reactivate user')
+    },
+  })
+
+  return (
+    <ConfirmDialog
+      open={!!user}
+      onOpenChange={onOpenChange}
+      title="Reactivate User"
+      description={`Reactivate ${user?.email}? They will be able to sign in again.`}
+      confirmText="Reactivate"
+      onConfirm={() => mutation.mutate()}
+      isLoading={mutation.isPending}
+    />
+  )
+}

--- a/frontend/src/components/auth/ChangePasswordDialog.tsx
+++ b/frontend/src/components/auth/ChangePasswordDialog.tsx
@@ -1,0 +1,177 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { AlertCircle, Check } from 'lucide-react'
+import { useAuthStore } from '@/lib/stores/auth-store'
+import { getApiUrl } from '@/lib/config'
+
+interface ChangePasswordDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialogProps) {
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+  const { token } = useAuthStore()
+
+  const resetForm = () => {
+    setCurrentPassword('')
+    setNewPassword('')
+    setConfirmPassword('')
+    setError(null)
+    setSuccess(false)
+  }
+
+  const handleClose = (open: boolean) => {
+    if (!open) resetForm()
+    onOpenChange(open)
+  }
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setError(null)
+
+    if (newPassword !== confirmPassword) {
+      setError('New passwords do not match')
+      return
+    }
+
+    if (newPassword.length < 8) {
+      setError('Password must be at least 8 characters')
+      return
+    }
+
+    setIsLoading(true)
+    try {
+      const apiUrl = await getApiUrl()
+      const response = await fetch(`${apiUrl}/api/auth/change-password`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          current_password: currentPassword,
+          new_password: newPassword,
+        }),
+      })
+
+      if (response.ok) {
+        setSuccess(true)
+        setTimeout(() => handleClose(false), 1500)
+      } else {
+        const data = await response.json().catch(() => ({}))
+        setError(data.detail || 'Failed to change password')
+      }
+    } catch {
+      setError('Unable to connect to server')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Change Password</DialogTitle>
+          <DialogDescription>
+            Enter your current password and choose a new one.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1.5">
+            <label htmlFor="current-password" className="text-sm font-medium">
+              Current Password
+            </label>
+            <Input
+              id="current-password"
+              type="password"
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              disabled={isLoading}
+              autoComplete="current-password"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label htmlFor="new-password" className="text-sm font-medium">
+              New Password
+            </label>
+            <Input
+              id="new-password"
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              disabled={isLoading}
+              autoComplete="new-password"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label htmlFor="confirm-password" className="text-sm font-medium">
+              Confirm New Password
+            </label>
+            <Input
+              id="confirm-password"
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              disabled={isLoading}
+              autoComplete="new-password"
+            />
+          </div>
+
+          {error && (
+            <div className="flex items-center gap-2 text-red-600 text-sm">
+              <AlertCircle className="h-4 w-4 flex-shrink-0" />
+              <span>{error}</span>
+            </div>
+          )}
+
+          {success && (
+            <div className="flex items-center gap-2 text-green-600 text-sm">
+              <Check className="h-4 w-4 flex-shrink-0" />
+              <span>Password changed successfully</span>
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleClose(false)}
+              disabled={isLoading}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={
+                isLoading ||
+                !currentPassword.trim() ||
+                !newPassword.trim() ||
+                !confirmPassword.trim()
+              }
+            >
+              {isLoading ? 'Updating...' : 'Update Password'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -8,19 +8,21 @@ import { getConfig } from '@/lib/config'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { AlertCircle } from 'lucide-react'
+import { AlertCircle, Shield } from 'lucide-react'
 import { LoadingSpinner } from '@/components/common/LoadingSpinner'
 import { BRANDING } from '@/config/branding'
 
 export function LoginForm() {
+  const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
-  const { login, isLoading, error } = useAuth()
+  const { login, isLoading, error, authMode } = useAuth()
   const { authRequired, checkAuthRequired, hasHydrated, isAuthenticated } = useAuthStore()
   const [isCheckingAuth, setIsCheckingAuth] = useState(true)
   const [configInfo, setConfigInfo] = useState<{ apiUrl: string; version: string; buildTime: string } | null>(null)
   const router = useRouter()
 
-  // Load config info for debugging
+  const isJwtMode = authMode === 'jwt'
+
   useEffect(() => {
     getConfig().then(cfg => {
       setConfigInfo({
@@ -33,17 +35,12 @@ export function LoginForm() {
     })
   }, [])
 
-  // Check if authentication is required on mount
   useEffect(() => {
-    if (!hasHydrated) {
-      return
-    }
+    if (!hasHydrated) return
 
     const checkAuth = async () => {
       try {
         const required = await checkAuthRequired()
-
-        // If auth is not required, redirect to saved path or jobs
         if (!required) {
           const savedPath = sessionStorage.getItem('redirectAfterLogin')
           if (savedPath) {
@@ -53,15 +50,13 @@ export function LoginForm() {
             router.push('/jobs')
           }
         }
-      } catch (error) {
-        console.error('Error checking auth requirement:', error)
-        // On error, assume auth is required to be safe
+      } catch {
+        // On error, assume auth is required
       } finally {
         setIsCheckingAuth(false)
       }
     }
 
-    // If we already know auth status, use it
     if (authRequired !== null) {
       if (!authRequired && isAuthenticated) {
         const savedPath = sessionStorage.getItem('redirectAfterLogin')
@@ -79,7 +74,6 @@ export function LoginForm() {
     }
   }, [hasHydrated, authRequired, checkAuthRequired, router, isAuthenticated])
 
-  // Show loading while checking if auth is required
   if (!hasHydrated || isCheckingAuth) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-background">
@@ -88,16 +82,13 @@ export function LoginForm() {
     )
   }
 
-  // If we still don't know if auth is required (connection error), show error
   if (authRequired === null) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-background p-4">
         <Card className="w-full max-w-md">
           <CardHeader className="text-center">
             <CardTitle>Connection Error</CardTitle>
-            <CardDescription>
-              Unable to connect to the API server
-            </CardDescription>
+            <CardDescription>Unable to connect to the API server</CardDescription>
           </CardHeader>
           <CardContent>
             <div className="space-y-4">
@@ -107,7 +98,6 @@ export function LoginForm() {
                   {error || 'Unable to connect to server. Please check if the API is running.'}
                 </div>
               </div>
-
               {configInfo && (
                 <div className="space-y-2 text-xs text-muted-foreground border-t pt-3">
                   <div className="font-medium">Diagnostic Information:</div>
@@ -115,18 +105,10 @@ export function LoginForm() {
                     <div>Version: {configInfo.version}</div>
                     <div>Built: {new Date(configInfo.buildTime).toLocaleString()}</div>
                     <div className="break-all">API URL: {configInfo.apiUrl}</div>
-                    <div className="break-all">Frontend: {typeof window !== 'undefined' ? window.location.href : 'N/A'}</div>
-                  </div>
-                  <div className="text-xs pt-2">
-                    Check browser console for detailed logs (look for 🔧 [Config] messages)
                   </div>
                 </div>
               )}
-
-              <Button
-                onClick={() => window.location.reload()}
-                className="w-full"
-              >
+              <Button onClick={() => window.location.reload()} className="w-full">
                 Retry Connection
               </Button>
             </div>
@@ -136,63 +118,111 @@ export function LoginForm() {
     )
   }
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    if (password.trim()) {
-      try {
+    if (isJwtMode) {
+      if (email.trim() && password.trim()) {
+        await login(email, password)
+      }
+    } else {
+      if (password.trim()) {
         await login(password)
-      } catch (error) {
-        console.error('Unhandled error during login:', error)
-        // The auth store should handle most errors, but this catches any unhandled ones
       }
     }
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background p-4">
-      <Card className="w-full max-w-md">
-        <CardHeader className="text-center">
-          <CardTitle>{BRANDING.name}</CardTitle>
-          <CardDescription>
-            Enter your password to access the application
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div>
-              <Input
-                type="password"
-                placeholder="Password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                disabled={isLoading}
-              />
-            </div>
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-background via-background to-muted/30 p-4">
+      <div className="w-full max-w-md space-y-6">
+        {/* Branding header */}
+        <div className="text-center space-y-2">
+          <div className="flex items-center justify-center gap-2">
+            <Shield className="h-8 w-8 text-primary" />
+            <h1 className="text-2xl font-bold tracking-tight">{BRANDING.name}</h1>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {BRANDING.tagline}
+          </p>
+        </div>
 
-            {error && (
-              <div className="flex items-center gap-2 text-red-600 text-sm">
-                <AlertCircle className="h-4 w-4" />
-                {error}
+        <Card className="border-border/50 shadow-lg">
+          <CardHeader className="text-center pb-4">
+            <CardTitle className="text-lg">Sign in to your account</CardTitle>
+            <CardDescription>
+              {isJwtMode
+                ? 'Enter your email and password to continue'
+                : 'Enter your password to access the application'}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              {isJwtMode && (
+                <div className="space-y-1.5">
+                  <label htmlFor="email" className="text-sm font-medium">
+                    Email
+                  </label>
+                  <Input
+                    id="email"
+                    type="email"
+                    placeholder="you@example.com"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    disabled={isLoading}
+                    autoComplete="email"
+                    autoFocus
+                  />
+                </div>
+              )}
+
+              <div className="space-y-1.5">
+                <label htmlFor="password" className="text-sm font-medium">
+                  Password
+                </label>
+                <Input
+                  id="password"
+                  type="password"
+                  placeholder="Password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  disabled={isLoading}
+                  autoComplete="current-password"
+                  autoFocus={!isJwtMode}
+                />
               </div>
-            )}
 
-            <Button
-              type="submit"
-              className="w-full"
-              disabled={isLoading || !password.trim()}
-            >
-              {isLoading ? 'Signing in...' : 'Sign In'}
-            </Button>
+              {error && (
+                <div className="flex items-center gap-2 text-red-600 text-sm bg-red-50 dark:bg-red-950/20 rounded-md p-2.5">
+                  <AlertCircle className="h-4 w-4 flex-shrink-0" />
+                  <span>{error}</span>
+                </div>
+              )}
+
+              <Button
+                type="submit"
+                className="w-full"
+                disabled={
+                  isLoading ||
+                  !password.trim() ||
+                  (isJwtMode && !email.trim())
+                }
+              >
+                {isLoading ? 'Signing in...' : 'Sign In'}
+              </Button>
+            </form>
 
             {configInfo && (
-              <div className="text-xs text-center text-muted-foreground pt-2 border-t">
-                <div>Version {configInfo.version}</div>
-                <div className="font-mono text-[10px]">{configInfo.apiUrl}</div>
+              <div className="text-xs text-center text-muted-foreground pt-4 mt-4 border-t">
+                <div>v{configInfo.version}</div>
               </div>
             )}
-          </form>
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
+
+        {/* Footer */}
+        <p className="text-center text-xs text-muted-foreground">
+          {BRANDING.footer.vendor}
+        </p>
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/auth/UserMenu.tsx
+++ b/frontend/src/components/auth/UserMenu.tsx
@@ -1,0 +1,132 @@
+'use client'
+
+import { useState } from 'react'
+import { useAuth } from '@/lib/hooks/use-auth'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  DropdownMenuLabel,
+} from '@/components/ui/dropdown-menu'
+import { LogOut, Key, User, ChevronUp } from 'lucide-react'
+import { ChangePasswordDialog } from '@/components/auth/ChangePasswordDialog'
+import { Badge } from '@/components/ui/badge'
+
+interface UserMenuProps {
+  collapsed?: boolean
+}
+
+export function UserMenu({ collapsed = false }: UserMenuProps) {
+  const { user, logout, authMode } = useAuth()
+  const [changePasswordOpen, setChangePasswordOpen] = useState(false)
+
+  // Don't render in legacy/no-auth mode
+  if (authMode !== 'jwt' || !user) return null
+
+  const initials = (user.name || user.email)
+    .split(' ')
+    .map((s) => s[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2)
+
+  if (collapsed) {
+    return (
+      <>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              className="w-full justify-center"
+              aria-label="User menu"
+            >
+              <div className="h-6 w-6 rounded-full bg-primary/10 text-primary flex items-center justify-center text-xs font-medium">
+                {initials}
+              </div>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" side="top" className="w-56">
+            <DropdownMenuLabel className="font-normal">
+              <div className="flex flex-col space-y-1">
+                <p className="text-sm font-medium">{user.name || user.username}</p>
+                <p className="text-xs text-muted-foreground truncate">{user.email}</p>
+              </div>
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={() => setChangePasswordOpen(true)}>
+              <Key className="h-4 w-4 mr-2" />
+              Change Password
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={logout}
+              className="text-destructive focus:text-destructive"
+            >
+              <LogOut className="h-4 w-4 mr-2" />
+              Sign Out
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <ChangePasswordDialog open={changePasswordOpen} onOpenChange={setChangePasswordOpen} />
+      </>
+    )
+  }
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            className="w-full justify-start gap-3 h-auto py-2"
+          >
+            <div className="h-7 w-7 rounded-full bg-primary/10 text-primary flex items-center justify-center text-xs font-medium flex-shrink-0">
+              {initials}
+            </div>
+            <div className="flex flex-col items-start text-left min-w-0 flex-1">
+              <span className="text-sm font-medium truncate w-full">
+                {user.name || user.username}
+              </span>
+              <span className="text-xs text-muted-foreground truncate w-full">
+                {user.email}
+              </span>
+            </div>
+            <ChevronUp className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" side="top" className="w-56">
+          <DropdownMenuLabel className="font-normal">
+            <div className="flex items-center gap-2">
+              <User className="h-4 w-4 text-muted-foreground" />
+              <div className="flex flex-col">
+                <span className="text-sm">{user.name || user.username}</span>
+                <div className="flex items-center gap-1.5">
+                  <Badge variant={user.role === 'admin' ? 'default' : 'secondary'} className="text-[10px] px-1.5 py-0">
+                    {user.role}
+                  </Badge>
+                </div>
+              </div>
+            </div>
+          </DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onClick={() => setChangePasswordOpen(true)}>
+            <Key className="h-4 w-4 mr-2" />
+            Change Password
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onClick={logout}
+            className="text-destructive focus:text-destructive"
+          >
+            <LogOut className="h-4 w-4 mr-2" />
+            Sign Out
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <ChangePasswordDialog open={changePasswordOpen} onOpenChange={setChangePasswordOpen} />
+    </>
+  )
+}

--- a/frontend/src/components/layout/AppSidebar.tsx
+++ b/frontend/src/components/layout/AppSidebar.tsx
@@ -23,6 +23,7 @@ import {
 import { ThemeToggle } from '@/components/common/ThemeToggle'
 import { Separator } from '@/components/ui/separator'
 import { VendorAttribution } from '@/components/brand/VendorAttribution'
+import { UserMenu } from '@/components/auth/UserMenu'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -48,7 +49,9 @@ const isAcmMode = process.env.NEXT_PUBLIC_ACM_MODE !== 'false'
 
 export function AppSidebar() {
   const pathname = usePathname()
-  const { logout } = useAuth()
+  const { logout, user, authMode } = useAuth()
+  const isAdmin = user?.role === 'admin'
+  const isJwtMode = authMode === 'jwt'
   const { isCollapsed, expandedSections, toggleCollapse, toggleSection } =
     useSidebarStore()
   const router = useRouter()
@@ -302,57 +305,68 @@ export function AppSidebar() {
             </div>
           )}
 
-          {/* Settings Dropdown */}
-          {isCollapsed ? (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  className="w-full justify-center"
-                  onClick={() => router.push('/settings')}
-                  aria-label="Settings"
-                >
-                  <Settings className="h-4 w-4" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="right">Settings</TooltipContent>
-            </Tooltip>
-          ) : (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="outline"
-                  className="w-full justify-start gap-3"
-                >
-                  <Settings className="h-4 w-4" />
-                  Settings
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="start" side="top" className="w-56">
-                {configureItems.map((item) => (
-                  <DropdownMenuItem key={item.name} asChild>
-                    <Link href={item.href} className="flex items-center gap-2">
-                      <item.icon className="h-4 w-4" />
-                      {item.name}
-                    </Link>
-                  </DropdownMenuItem>
-                ))}
-                <DropdownMenuSeparator />
-                <DropdownMenuItem asChild>
-                  <div className="flex items-center gap-2">
-                    <ThemeToggle />
-                  </div>
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  onClick={logout}
-                  className="text-destructive focus:text-destructive"
-                >
-                  <LogOut className="h-4 w-4 mr-2" />
-                  Sign Out
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+          {/* User Menu (JWT mode) */}
+          {isJwtMode && <UserMenu collapsed={isCollapsed} />}
+
+          {/* Settings Dropdown — shown for admins or non-JWT mode */}
+          {(!isJwtMode || isAdmin) && (
+            <>
+              {isCollapsed ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      className="w-full justify-center"
+                      onClick={() => router.push('/settings')}
+                      aria-label="Settings"
+                    >
+                      <Settings className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="right">Settings</TooltipContent>
+                </Tooltip>
+              ) : (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="outline"
+                      className="w-full justify-start gap-3"
+                    >
+                      <Settings className="h-4 w-4" />
+                      Settings
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="start" side="top" className="w-56">
+                    {configureItems.map((item) => (
+                      <DropdownMenuItem key={item.name} asChild>
+                        <Link href={item.href} className="flex items-center gap-2">
+                          <item.icon className="h-4 w-4" />
+                          {item.name}
+                        </Link>
+                      </DropdownMenuItem>
+                    ))}
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem asChild>
+                      <div className="flex items-center gap-2">
+                        <ThemeToggle />
+                      </div>
+                    </DropdownMenuItem>
+                    {!isJwtMode && (
+                      <>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          onClick={logout}
+                          className="text-destructive focus:text-destructive"
+                        >
+                          <LogOut className="h-4 w-4 mr-2" />
+                          Sign Out
+                        </DropdownMenuItem>
+                      </>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
+            </>
           )}
 
           {/* Footer links */}

--- a/frontend/src/config/navigation.ts
+++ b/frontend/src/config/navigation.ts
@@ -16,6 +16,7 @@ import {
   ListChecks,
   House,
   BookText,
+  Users,
 } from 'lucide-react'
 import { MARKETING_DOCS_URL, MARKETING_URL } from '@/lib/site-urls'
 
@@ -68,6 +69,7 @@ export const navigationConfig: NavGroup[] = [
       { name: 'Parsers', href: '/settings/parsers', icon: FileCode },
       { name: 'Field Schema', href: '/settings/field-schema', icon: ListChecks, acmOnly: true },
       { name: 'Processing', href: '/settings/processing', icon: Cog },
+      { name: 'User Management', href: '/settings/users', icon: Users },
       { name: 'General', href: '/settings', icon: SlidersHorizontal },
     ],
   },

--- a/frontend/src/lib/hooks/use-auth.ts
+++ b/frontend/src/lib/hooks/use-auth.ts
@@ -9,39 +9,53 @@ export function useAuth() {
   const {
     isAuthenticated,
     isLoading,
+    user,
     login,
+    loginLegacy,
     logout,
     checkAuth,
     checkAuthRequired,
+    fetchMe,
     error,
     hasHydrated,
-    authRequired
+    authRequired,
+    authMode,
   } = useAuthStore()
 
   useEffect(() => {
-    // Only check auth after the store has hydrated from localStorage
     if (hasHydrated) {
-      // First check if auth is required
       if (authRequired === null) {
         checkAuthRequired().then((required) => {
-          // If auth is required, check if we have valid credentials
           if (required) {
             checkAuth()
           }
-        })
+        }).catch(() => {})
       } else if (authRequired) {
-        // Auth is required, check credentials
         checkAuth()
       }
-      // If authRequired === false, we're already authenticated (set in checkAuthRequired)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasHydrated, authRequired])
 
-  const handleLogin = async (password: string) => {
-    const success = await login(password)
+  // Fetch user profile when authenticated in JWT mode
+  useEffect(() => {
+    if (isAuthenticated && authMode === 'jwt' && !user) {
+      fetchMe()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAuthenticated, authMode])
+
+  const handleLogin = async (emailOrPassword: string, password?: string) => {
+    let success: boolean
+    if (authMode === 'jwt' && password) {
+      // JWT mode: email + password
+      success = await login(emailOrPassword, password)
+    } else {
+      // Legacy mode: password only
+      success = await loginLegacy(emailOrPassword)
+    }
+
     if (success) {
-      // Check if there's a stored redirect path
       const redirectPath = sessionStorage.getItem('redirectAfterLogin')
       if (redirectPath) {
         sessionStorage.removeItem('redirectAfterLogin')
@@ -60,9 +74,11 @@ export function useAuth() {
 
   return {
     isAuthenticated,
-    isLoading: isLoading || !hasHydrated, // Treat lack of hydration as loading
+    isLoading: isLoading || !hasHydrated,
     error,
+    user,
+    authMode,
     login: handleLogin,
-    logout: handleLogout
+    logout: handleLogout,
   }
 }

--- a/frontend/src/lib/stores/auth-store.ts
+++ b/frontend/src/lib/stores/auth-store.ts
@@ -1,21 +1,35 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { getApiUrl } from '@/lib/config'
+import type { User } from '@/lib/types/auth'
 
 interface AuthState {
   isAuthenticated: boolean
   token: string | null
+  user: User | null
   isLoading: boolean
   error: string | null
   lastAuthCheck: number | null
   isCheckingAuth: boolean
   hasHydrated: boolean
   authRequired: boolean | null
+  authMode: 'legacy' | 'jwt' | 'none' | null
   setHasHydrated: (state: boolean) => void
   checkAuthRequired: () => Promise<boolean>
-  login: (password: string) => Promise<boolean>
+  login: (email: string, password: string) => Promise<boolean>
+  loginLegacy: (password: string) => Promise<boolean>
   logout: () => void
   checkAuth: () => Promise<boolean>
+  fetchMe: () => Promise<void>
+}
+
+function setCookie(name: string, value: string, days: number) {
+  const expires = new Date(Date.now() + days * 864e5).toUTCString()
+  document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/; SameSite=Lax`
+}
+
+function deleteCookie(name: string) {
+  document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`
 }
 
 export const useAuthStore = create<AuthState>()(
@@ -23,12 +37,14 @@ export const useAuthStore = create<AuthState>()(
     (set, get) => ({
       isAuthenticated: false,
       token: null,
+      user: null,
       isLoading: false,
       error: null,
       lastAuthCheck: null,
       isCheckingAuth: false,
       hasHydrated: false,
       authRequired: null,
+      authMode: null,
 
       setHasHydrated: (state: boolean) => {
         set({ hasHydrated: state })
@@ -47,121 +63,158 @@ export const useAuthStore = create<AuthState>()(
 
           const data = await response.json()
           const required = data.auth_enabled || false
-          set({ authRequired: required })
+          const mode = data.mode || 'none'
+          set({ authRequired: required, authMode: mode })
 
-          // If auth is not required, mark as authenticated
           if (!required) {
-            set({ isAuthenticated: true, token: 'not-required' })
+            set({ isAuthenticated: true, token: 'not-required', user: null })
           }
 
           return required
         } catch (error) {
           console.error('Failed to check auth status:', error)
 
-          // If it's a network error, set a more helpful error message
           if (error instanceof TypeError && error.message.includes('Failed to fetch')) {
             set({
               error: 'Unable to connect to server. Please check if the API is running.',
-              authRequired: null  // Don't assume auth is required if we can't connect
+              authRequired: null,
             })
           } else {
-            // For other errors, default to requiring auth to be safe
             set({ authRequired: true })
           }
-
-          // Re-throw the error so the UI can handle it
           throw error
         }
       },
 
-      login: async (password: string) => {
+      login: async (email: string, password: string) => {
         set({ isLoading: true, error: null })
         try {
           const apiUrl = await getApiUrl()
-
-          // Test auth with notebooks endpoint
-          const response = await fetch(`${apiUrl}/api/notebooks`, {
-            method: 'GET',
-            headers: {
-              'Authorization': `Bearer ${password}`,
-              'Content-Type': 'application/json'
-            }
+          const response = await fetch(`${apiUrl}/api/auth/login`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email, password }),
           })
-          
+
           if (response.ok) {
-            set({ 
-              isAuthenticated: true, 
-              token: password, 
+            const data = await response.json()
+            // Sync token to cookie for Next.js middleware
+            setCookie('acm_token', data.token, 1)
+            set({
+              isAuthenticated: true,
+              token: data.token,
+              user: data.user,
               isLoading: false,
               lastAuthCheck: Date.now(),
-              error: null
+              error: null,
             })
             return true
           } else {
-            let errorMessage = 'Authentication failed'
-            if (response.status === 401) {
-              errorMessage = 'Invalid password. Please try again.'
-            } else if (response.status === 403) {
-              errorMessage = 'Access denied. Please check your credentials.'
-            } else if (response.status >= 500) {
-              errorMessage = 'Server error. Please try again later.'
-            } else {
-              errorMessage = `Authentication failed (${response.status})`
-            }
-            
-            set({ 
-              error: errorMessage,
+            const errorData = await response.json().catch(() => ({}))
+            set({
+              error: errorData.detail || 'Invalid email or password',
               isLoading: false,
               isAuthenticated: false,
-              token: null
+              token: null,
+              user: null,
             })
             return false
           }
         } catch (error) {
-          console.error('Network error during auth:', error)
-          let errorMessage = 'Authentication failed'
-          
-          if (error instanceof TypeError && error.message.includes('Failed to fetch')) {
-            errorMessage = 'Unable to connect to server. Please check if the API is running.'
-          } else if (error instanceof Error) {
-            errorMessage = `Network error: ${error.message}`
-          } else {
-            errorMessage = 'An unexpected error occurred during authentication'
-          }
-          
-          set({ 
-            error: errorMessage,
+          console.error('Login error:', error)
+          set({
+            error: error instanceof TypeError && error.message.includes('Failed to fetch')
+              ? 'Unable to connect to server.'
+              : 'An unexpected error occurred',
             isLoading: false,
             isAuthenticated: false,
-            token: null
+            token: null,
+            user: null,
           })
           return false
         }
       },
-      
+
+      loginLegacy: async (password: string) => {
+        set({ isLoading: true, error: null })
+        try {
+          const apiUrl = await getApiUrl()
+          const response = await fetch(`${apiUrl}/api/notebooks`, {
+            method: 'GET',
+            headers: {
+              'Authorization': `Bearer ${password}`,
+              'Content-Type': 'application/json',
+            },
+          })
+
+          if (response.ok) {
+            setCookie('acm_token', password, 1)
+            set({
+              isAuthenticated: true,
+              token: password,
+              user: null,
+              isLoading: false,
+              lastAuthCheck: Date.now(),
+              error: null,
+            })
+            return true
+          } else {
+            set({
+              error: response.status === 401 ? 'Invalid password.' : `Authentication failed (${response.status})`,
+              isLoading: false,
+              isAuthenticated: false,
+              token: null,
+              user: null,
+            })
+            return false
+          }
+        } catch (error) {
+          console.error('Legacy login error:', error)
+          set({
+            error: 'Unable to connect to server.',
+            isLoading: false,
+            isAuthenticated: false,
+            token: null,
+            user: null,
+          })
+          return false
+        }
+      },
+
       logout: () => {
-        set({ 
-          isAuthenticated: false, 
-          token: null, 
-          error: null 
+        deleteCookie('acm_token')
+        set({
+          isAuthenticated: false,
+          token: null,
+          user: null,
+          error: null,
         })
       },
-      
+
+      fetchMe: async () => {
+        const { token } = get()
+        if (!token || token === 'not-required') return
+        try {
+          const apiUrl = await getApiUrl()
+          const response = await fetch(`${apiUrl}/api/auth/me`, {
+            headers: { 'Authorization': `Bearer ${token}` },
+          })
+          if (response.ok) {
+            const user = await response.json()
+            set({ user })
+          }
+        } catch {
+          // Non-fatal — user info is optional
+        }
+      },
+
       checkAuth: async () => {
         const state = get()
         const { token, lastAuthCheck, isCheckingAuth, isAuthenticated } = state
 
-        // If already checking, return current auth state
-        if (isCheckingAuth) {
-          return isAuthenticated
-        }
+        if (isCheckingAuth) return isAuthenticated
+        if (!token) return false
 
-        // If no token, not authenticated
-        if (!token) {
-          return false
-        }
-
-        // If we checked recently (within 30 seconds) and are authenticated, skip
         const now = Date.now()
         if (isAuthenticated && lastAuthCheck && (now - lastAuthCheck) < 30000) {
           return true
@@ -171,42 +224,47 @@ export const useAuthStore = create<AuthState>()(
 
         try {
           const apiUrl = await getApiUrl()
-
-          const response = await fetch(`${apiUrl}/api/notebooks`, {
+          // Use /auth/me for JWT mode, /notebooks for legacy
+          const endpoint = state.authMode === 'jwt' ? '/api/auth/me' : '/api/notebooks'
+          const response = await fetch(`${apiUrl}${endpoint}`, {
             method: 'GET',
             headers: {
               'Authorization': `Bearer ${token}`,
-              'Content-Type': 'application/json'
-            }
+              'Content-Type': 'application/json',
+            },
           })
-          
+
           if (response.ok) {
-            set({ 
-              isAuthenticated: true, 
+            set({
+              isAuthenticated: true,
               lastAuthCheck: now,
-              isCheckingAuth: false 
+              isCheckingAuth: false,
             })
             return true
           } else {
+            deleteCookie('acm_token')
             set({
               isAuthenticated: false,
               token: null,
+              user: null,
               lastAuthCheck: null,
-              isCheckingAuth: false
+              isCheckingAuth: false,
             })
             return false
           }
         } catch (error) {
           console.error('checkAuth error:', error)
-          set({ 
-            isAuthenticated: false, 
+          deleteCookie('acm_token')
+          set({
+            isAuthenticated: false,
             token: null,
+            user: null,
             lastAuthCheck: null,
-            isCheckingAuth: false 
+            isCheckingAuth: false,
           })
           return false
         }
-      }
+      },
     }),
     {
       name: 'auth-storage',
@@ -214,10 +272,16 @@ export const useAuthStore = create<AuthState>()(
         token: state.token,
         isAuthenticated: state.isAuthenticated,
         authRequired: state.authRequired,
+        authMode: state.authMode,
+        user: state.user,
       }),
       onRehydrateStorage: () => (state) => {
         state?.setHasHydrated(true)
-      }
+        // Sync token to cookie on rehydrate
+        if (state?.token && state.token !== 'not-required') {
+          setCookie('acm_token', state.token, 1)
+        }
+      },
     }
   )
 )

--- a/frontend/src/lib/types/auth.ts
+++ b/frontend/src/lib/types/auth.ts
@@ -1,10 +1,25 @@
+export interface User {
+  id: string
+  email: string
+  username: string
+  role: 'admin' | 'user'
+  name: string
+}
+
 export interface AuthState {
   isAuthenticated: boolean
   token: string | null
+  user: User | null
   isLoading: boolean
   error: string | null
 }
 
 export interface LoginCredentials {
+  email: string
   password: string
+}
+
+export interface ChangePasswordRequest {
+  current_password: string
+  new_password: string
 }

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -7,11 +7,30 @@ const REDIRECTS: Record<string, string> = {
   '/models': '/settings/models',
 }
 
+const PUBLIC_PATHS = ['/login']
+
 export function middleware(request: NextRequest) {
   const { pathname, search } = request.nextUrl
 
+  // Handle legacy redirects first
   if (pathname in REDIRECTS) {
     return NextResponse.redirect(new URL(`${REDIRECTS[pathname]}${search}`, request.url))
+  }
+
+  // Skip public paths (login page)
+  if (PUBLIC_PATHS.includes(pathname)) {
+    return NextResponse.next()
+  }
+
+  // Check for auth token in cookie (synced from localStorage by auth store)
+  const token = request.cookies.get('acm_token')?.value
+
+  if (!token) {
+    const loginUrl = new URL('/login', request.url)
+    if (pathname !== '/') {
+      loginUrl.searchParams.set('redirect', pathname)
+    }
+    return NextResponse.redirect(loginUrl)
   }
 
   return NextResponse.next()

--- a/migrations/57.surrealql
+++ b/migrations/57.surrealql
@@ -1,0 +1,17 @@
+-- Migration 57: User authentication table
+-- Supports per-user auth with email/password, admin/user roles, and soft delete via status field.
+
+DEFINE TABLE IF NOT EXISTS user SCHEMAFULL;
+
+DEFINE FIELD username ON user TYPE string;
+DEFINE FIELD email ON user TYPE string ASSERT string::is::email($value);
+DEFINE FIELD password_hash ON user TYPE string;
+DEFINE FIELD role ON user TYPE string ASSERT $value IN ['admin', 'user'] DEFAULT 'user';
+DEFINE FIELD status ON user TYPE string ASSERT $value IN ['active', 'inactive'] DEFAULT 'active';
+DEFINE FIELD name ON user TYPE option<string>;
+DEFINE FIELD created_at ON user TYPE datetime DEFAULT time::now();
+DEFINE FIELD updated_at ON user TYPE datetime DEFAULT time::now();
+DEFINE FIELD last_login ON user TYPE option<datetime>;
+
+DEFINE INDEX idx_user_email ON user FIELDS email UNIQUE;
+DEFINE INDEX idx_user_username ON user FIELDS username UNIQUE;

--- a/migrations/57_down.surrealql
+++ b/migrations/57_down.surrealql
@@ -1,0 +1,4 @@
+-- Rollback migration 57: Remove user authentication table
+REMOVE INDEX IF EXISTS idx_user_username ON user;
+REMOVE INDEX IF EXISTS idx_user_email ON user;
+REMOVE TABLE IF EXISTS user;

--- a/migrations/58.surrealql
+++ b/migrations/58.surrealql
@@ -1,0 +1,12 @@
+-- Migration 58: Add owner field for per-user data isolation
+-- Adds owner (record<user>) to core content tables. Null for legacy/system records.
+
+DEFINE FIELD IF NOT EXISTS owner ON TABLE source TYPE option<record<user>>;
+DEFINE FIELD IF NOT EXISTS owner ON TABLE notebook TYPE option<record<user>>;
+DEFINE FIELD IF NOT EXISTS owner ON TABLE acm_record TYPE option<record<user>>;
+DEFINE FIELD IF NOT EXISTS owner ON TABLE building_record TYPE option<record<user>>;
+
+DEFINE INDEX IF NOT EXISTS idx_source_owner ON source FIELDS owner;
+DEFINE INDEX IF NOT EXISTS idx_notebook_owner ON notebook FIELDS owner;
+DEFINE INDEX IF NOT EXISTS idx_acm_record_owner ON acm_record FIELDS owner;
+DEFINE INDEX IF NOT EXISTS idx_building_record_owner ON building_record FIELDS owner;

--- a/migrations/58_down.surrealql
+++ b/migrations/58_down.surrealql
@@ -1,0 +1,10 @@
+-- Rollback migration 58: Remove owner fields and indexes
+REMOVE INDEX IF EXISTS idx_building_record_owner ON building_record;
+REMOVE INDEX IF EXISTS idx_acm_record_owner ON acm_record;
+REMOVE INDEX IF EXISTS idx_notebook_owner ON notebook;
+REMOVE INDEX IF EXISTS idx_source_owner ON source;
+
+REMOVE FIELD IF EXISTS owner ON TABLE building_record;
+REMOVE FIELD IF EXISTS owner ON TABLE acm_record;
+REMOVE FIELD IF EXISTS owner ON TABLE notebook;
+REMOVE FIELD IF EXISTS owner ON TABLE source;

--- a/open_notebook/database/async_migrate.py
+++ b/open_notebook/database/async_migrate.py
@@ -150,6 +150,10 @@ class AsyncMigrationManager:
             AsyncMigration.from_file("migrations/52.surrealql"),
             AsyncMigration.from_file("migrations/53.surrealql"),
             AsyncMigration.from_file("migrations/54.surrealql"),
+            AsyncMigration.from_file("migrations/55.surrealql"),
+            AsyncMigration.from_file("migrations/56.surrealql"),
+            AsyncMigration.from_file("migrations/57.surrealql"),
+            AsyncMigration.from_file("migrations/58.surrealql"),
         ]
         self.down_migrations = [
             AsyncMigration.from_file("migrations/1_down.surrealql"),
@@ -206,6 +210,10 @@ class AsyncMigrationManager:
             AsyncMigration.from_file("migrations/52_down.surrealql"),
             AsyncMigration.from_file("migrations/53_down.surrealql"),
             AsyncMigration.from_file("migrations/54_down.surrealql"),
+            AsyncMigration.from_file("migrations/55_down.surrealql"),
+            AsyncMigration.from_file("migrations/56_down.surrealql"),
+            AsyncMigration.from_file("migrations/57_down.surrealql"),
+            AsyncMigration.from_file("migrations/58_down.surrealql"),
         ]
         self.runner = AsyncMigrationRunner(
             up_migrations=self.up_migrations,

--- a/open_notebook/domain/acm.py
+++ b/open_notebook/domain/acm.py
@@ -71,6 +71,7 @@ class ACMRecord(ObjectModel):
 
     # Foreign key to source document
     source_id: str  # Will be record<source> in DB
+    owner: Optional[str] = None
 
     # School identification
     school_name: Optional[str] = None

--- a/open_notebook/domain/notebook.py
+++ b/open_notebook/domain/notebook.py
@@ -18,6 +18,7 @@ class Notebook(ObjectModel):
     name: str
     description: str
     archived: Optional[bool] = False
+    owner: Optional[str] = None
 
     @field_validator("name")
     @classmethod
@@ -148,6 +149,7 @@ class Source(ObjectModel):
     topics: Optional[List[str]] = Field(default_factory=list)
     full_text: Optional[str] = None
     review_status: Optional[str] = None
+    owner: Optional[str] = None
     command: Optional[str] = Field(
         default=None, description="Link to surreal-commands processing job"
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,8 @@ dependencies = [
     "runpod>=1.8.1",
     "runpod-flash>=1.9.1",
     "copilotkit>=0.1.78",
+    "PyJWT>=2.8.0",
+    "bcrypt>=4.0.0",
 ]
 
 [tool.setuptools]

--- a/uv.lock
+++ b/uv.lock
@@ -3697,6 +3697,7 @@ dependencies = [
     { name = "ag-ui-langgraph" },
     { name = "ag-ui-protocol" },
     { name = "ai-prompter" },
+    { name = "bcrypt" },
     { name = "content-core" },
     { name = "copilotkit" },
     { name = "docling" },
@@ -3722,6 +3723,7 @@ dependencies = [
     { name = "openpyxl" },
     { name = "podcast-creator" },
     { name = "pydantic" },
+    { name = "pyjwt" },
     { name = "python-dotenv" },
     { name = "runpod" },
     { name = "runpod-flash" },
@@ -3765,6 +3767,7 @@ requires-dist = [
     { name = "ag-ui-langgraph", specifier = ">=0.0.25" },
     { name = "ag-ui-protocol", specifier = ">=0.1.11" },
     { name = "ai-prompter", specifier = ">=0.3" },
+    { name = "bcrypt", specifier = ">=4.0.0" },
     { name = "content-core", specifier = ">=1.0.2" },
     { name = "copilotkit", specifier = ">=0.1.78" },
     { name = "docling", specifier = ">=2.75.0" },
@@ -3794,6 +3797,7 @@ requires-dist = [
     { name = "podcast-creator", specifier = ">=0.7.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.1" },
     { name = "pydantic", specifier = ">=2.9.2" },
+    { name = "pyjwt", specifier = ">=2.8.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "rich", marker = "extra == 'dev'", specifier = ">=13.0.0" },
@@ -6023,12 +6027,12 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu126/torch-2.10.0%2Bcu126-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:3a5fb967ffb53ffa0d2579c9819491cfc36c557040de6fdeabcfcfb45df019bc" },
-    { url = "https://download.pytorch.org/whl/cu126/torch-2.10.0%2Bcu126-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a9a9ba3b2baf23c044499ffbcbed88e04b6e38b94189c7dc42dd2cfcdd8c55c0" },
-    { url = "https://download.pytorch.org/whl/cu126/torch-2.10.0%2Bcu126-cp311-cp311-win_amd64.whl", hash = "sha256:4749cd32e32ed55179ff2ff0407e0ae5077fe4d332bfa49258f4578d09eccb40" },
-    { url = "https://download.pytorch.org/whl/cu126/torch-2.10.0%2Bcu126-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:81264238b3d8840276dd30c31f393e325b8f5da6390d18ac2a80dacecfd693ea" },
-    { url = "https://download.pytorch.org/whl/cu126/torch-2.10.0%2Bcu126-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:2a7a569206f07965eff69b28e147676540bb0ba6e1a39410802b6e4708cb8356" },
-    { url = "https://download.pytorch.org/whl/cu126/torch-2.10.0%2Bcu126-cp312-cp312-win_amd64.whl", hash = "sha256:95d8409b8a15191de4c2958e86ca47f3ea8f9739b994ee4ca0e7586f37336413" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.10.0%2Bcu126-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:3a5fb967ffb53ffa0d2579c9819491cfc36c557040de6fdeabcfcfb45df019bc" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.10.0%2Bcu126-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a9a9ba3b2baf23c044499ffbcbed88e04b6e38b94189c7dc42dd2cfcdd8c55c0" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.10.0%2Bcu126-cp311-cp311-win_amd64.whl", hash = "sha256:4749cd32e32ed55179ff2ff0407e0ae5077fe4d332bfa49258f4578d09eccb40" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.10.0%2Bcu126-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:81264238b3d8840276dd30c31f393e325b8f5da6390d18ac2a80dacecfd693ea" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.10.0%2Bcu126-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:2a7a569206f07965eff69b28e147676540bb0ba6e1a39410802b6e4708cb8356" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.10.0%2Bcu126-cp312-cp312-win_amd64.whl", hash = "sha256:95d8409b8a15191de4c2958e86ca47f3ea8f9739b994ee4ca0e7586f37336413" },
 ]
 
 [[package]]
@@ -6041,12 +6045,12 @@ dependencies = [
     { name = "torch" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu126/torchvision-0.25.0%2Bcu126-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:1bacf3a2c4c5d77615be7fa77b39976aace0dfeeb580a549776cae192790401d" },
-    { url = "https://download.pytorch.org/whl/cu126/torchvision-0.25.0%2Bcu126-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:09a1c80106b4cbf750af8af4ef0cde98a03ddd963dcf0f843b89e03a061959ae" },
-    { url = "https://download.pytorch.org/whl/cu126/torchvision-0.25.0%2Bcu126-cp311-cp311-win_amd64.whl", hash = "sha256:3476ee36355960b9559beee84491b8bd3d062e63ef612dd84a54b3c127eaa5d8" },
-    { url = "https://download.pytorch.org/whl/cu126/torchvision-0.25.0%2Bcu126-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:968f7dea6a16c8127d23416a55845dffcfe1b08dee7f50cb8cdeb950683a6752" },
-    { url = "https://download.pytorch.org/whl/cu126/torchvision-0.25.0%2Bcu126-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:5831326b6710366b44c0124ce197b416b7b896efa27340c235081cc7f52870e5" },
-    { url = "https://download.pytorch.org/whl/cu126/torchvision-0.25.0%2Bcu126-cp312-cp312-win_amd64.whl", hash = "sha256:57a8a103814c344d91c32425ba38a53daac4bf4aab074aaaea7b6bab4c22fb7b" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.25.0%2Bcu126-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:1bacf3a2c4c5d77615be7fa77b39976aace0dfeeb580a549776cae192790401d" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.25.0%2Bcu126-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:09a1c80106b4cbf750af8af4ef0cde98a03ddd963dcf0f843b89e03a061959ae" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.25.0%2Bcu126-cp311-cp311-win_amd64.whl", hash = "sha256:3476ee36355960b9559beee84491b8bd3d062e63ef612dd84a54b3c127eaa5d8" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.25.0%2Bcu126-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:968f7dea6a16c8127d23416a55845dffcfe1b08dee7f50cb8cdeb950683a6752" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.25.0%2Bcu126-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:5831326b6710366b44c0124ce197b416b7b896efa27340c235081cc7f52870e5" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torchvision-0.25.0%2Bcu126-cp312-cp312-win_amd64.whl", hash = "sha256:57a8a103814c344d91c32425ba38a53daac4bf4aab074aaaea7b6bab4c22fb7b" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- **JWT authentication** with SurrealDB-native user storage — bcrypt password hashing, 24h token expiry, admin user seeding via `commands/create_admin.py`
- **Multi-tenant data ownership** — `owner` field on source/notebook/acm_record/building_record tables (migrations 57-58), API endpoints filter by authenticated user
- **Admin User Management page** at `/settings/users` — full CRUD: create users, edit name/role, reset passwords, deactivate/reactivate accounts
- **Frontend auth flow** — Next.js middleware route protection, Zustand auth store, LoginForm, UserMenu with change password dialog, Settings dropdown integration

## Files changed (33 files, +2631/-286)
| Area | Key files |
|------|-----------|
| Backend auth | `api/auth_service.py`, `api/auth_dependencies.py`, `api/routers/admin.py`, `api/routers/auth.py` |
| Migrations | `migrations/57.surrealql` (user table), `migrations/58.surrealql` (owner fields) |
| Frontend auth | `auth-store.ts`, `use-auth.ts`, `LoginForm.tsx`, `UserMenu.tsx`, `middleware.ts` |
| User management | `settings/users/page.tsx`, `ChangePasswordDialog.tsx` |
| Data ownership | `api/routers/notebooks.py`, `api/routers/sources.py`, `open_notebook/domain/*.py` |

## Test plan
- [x] Admin user creation via `uv run python -m commands.create_admin`
- [x] Login flow: email/password → JWT → dashboard redirect
- [x] Route protection: unauthenticated users redirected to /login
- [x] User management: create, edit, deactivate, reactivate, reset password (all verified via browser)
- [x] `list_users()` returns all users (fixed SurrealDB response unwrapping bug)
- [x] Settings dropdown shows "User Management" for admin users
- [ ] Backend lint: `uv run ruff check .`
- [ ] Frontend build: `cd frontend && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)